### PR TITLE
feat(protocol): 添加HTTP和HTTPS协议支持

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ docker-compose up -d
 | 客户端 | 支持协议 |
 |:---|:---|
 | **v2ray** | base64 通用格式 |
-| **clash** | ss, ssr, trojan, vmess, vless, hy, hy2, tuic, AnyTLS, Socks5 |
+| **clash** | ss, ssr, trojan, vmess, vless, hy, hy2, tuic, AnyTLS, Socks5, HTTP, HTTPS |
 | **surge** | ss, trojan, vmess, hy2, tuic |
 
 ---

--- a/api/clients.go
+++ b/api/clients.go
@@ -198,8 +198,8 @@ func GetV2ray(c *gin.Context) {
 			}
 			baselist += strings.Join(links, "\n") + "\n"
 			continue
-		//如果是订阅转换（以 http:// 或 https:// 开头）
-		case strings.HasPrefix(v.Link, "http://") || strings.HasPrefix(v.Link, "https://"):
+		//如果是订阅转换（以 http:// 或 https:// 开头，但不是HTTP/HTTPS代理节点）
+		case (strings.HasPrefix(v.Link, "http://") || strings.HasPrefix(v.Link, "https://")) && !protocol.IsHTTPLink(v.Link):
 			resp, err := http.Get(v.Link)
 			if err != nil {
 				utils.Error("Error getting link: %v", err)
@@ -385,8 +385,8 @@ func GetClash(c *gin.Context) {
 				})
 			}
 			continue
-		//如果是订阅转换（以 http:// 或 https:// 开头）
-		case strings.HasPrefix(v.Link, "http://") || strings.HasPrefix(v.Link, "https://"):
+		//如果是订阅转换（以 http:// 或 https:// 开头，但不是HTTP/HTTPS代理节点）
+		case (strings.HasPrefix(v.Link, "http://") || strings.HasPrefix(v.Link, "https://")) && !protocol.IsHTTPLink(v.Link):
 			resp, err := http.Get(v.Link)
 			if err != nil {
 				utils.Error("获取包含链接失败: %v", err)
@@ -534,8 +534,8 @@ func GetSurge(c *gin.Context) {
 			}
 			urls = append(urls, links...)
 			continue
-		//如果是订阅转换（以 http:// 或 https:// 开头）
-		case strings.HasPrefix(v.Link, "http://") || strings.HasPrefix(v.Link, "https://"):
+		//如果是订阅转换（以 http:// 或 https:// 开头，但不是HTTP/HTTPS代理节点）
+		case (strings.HasPrefix(v.Link, "http://") || strings.HasPrefix(v.Link, "https://")) && !protocol.IsHTTPLink(v.Link):
 			resp, err := http.Get(v.Link)
 			if err != nil {
 				utils.Error("Error getting link: %v", err)

--- a/api/node.go
+++ b/api/node.go
@@ -169,6 +169,19 @@ func NodeUpdadte(c *gin.Context) {
 		Node.LinkAddress = socks5.Server + ":" + utils.GetPortString(socks5.Port)
 		Node.LinkHost = socks5.Server
 		Node.LinkPort = utils.GetPortString(socks5.Port)
+	case u.Scheme == "http" || u.Scheme == "https":
+		httpProxy, err := protocol.DecodeHTTPURL(link)
+		if err != nil {
+			utils.Error("解析节点链接失败: %v", err)
+			return
+		}
+		if Node.Name == "" {
+			Node.Name = httpProxy.Name
+		}
+		Node.LinkName = httpProxy.Name
+		Node.LinkAddress = httpProxy.Server + ":" + utils.GetPortString(httpProxy.Port)
+		Node.LinkHost = httpProxy.Server
+		Node.LinkPort = utils.GetPortString(httpProxy.Port)
 	case u.Scheme == "wg" || u.Scheme == "wireguard":
 		wg, err := protocol.DecodeWireGuardURL(link)
 		if err != nil {

--- a/models/subcription.go
+++ b/models/subcription.go
@@ -1401,6 +1401,10 @@ func generateProtocolKey(link string, protoType string, fields []string) string 
 		protoObj, err = protocol.DecodeAnyTLSURL(link)
 	case "socks5":
 		protoObj, err = protocol.DecodeSocks5URL(link)
+	case "http":
+		protoObj, err = protocol.DecodeHTTPURL(link)
+	case "https":
+		protoObj, err = protocol.DecodeHTTPURL(link)
 	default:
 		return ""
 	}

--- a/node/protocol/http.go
+++ b/node/protocol/http.go
@@ -1,0 +1,194 @@
+package protocol
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+	"strconv"
+	"strings"
+	"sublink/utils"
+)
+
+// HTTP HTTP代理结构体
+type HTTP struct {
+	Name            string
+	Server          string
+	Port            interface{}
+	Username        string
+	Password        string
+	TLS             bool
+	SkipCertVerify  bool
+	SNI             string
+}
+
+// IsHTTPLink 判断链接是否是HTTP/HTTPS代理节点链接
+// 用于区分HTTP/HTTPS代理节点和订阅转换链接
+func IsHTTPLink(link string) bool {
+	if !strings.HasPrefix(strings.ToLower(link), "http://") && !strings.HasPrefix(strings.ToLower(link), "https://") {
+		return false
+	}
+	
+	// 尝试解析为HTTP/HTTPS代理节点
+	_, err := DecodeHTTPURL(link)
+	if err != nil {
+		return false
+	}
+	
+	// 进一步验证：HTTP/HTTPS代理节点必须包含有效的服务器地址和端口
+	// 订阅转换链接通常不包含@符号（或者@符号后面不是有效的host:port格式）
+	u, err := url.Parse(link)
+	if err != nil {
+		return false
+	}
+	
+	// 检查是否有有效的host和port
+	host, port, err := net.SplitHostPort(u.Host)
+	if err != nil {
+		// 如果没有端口，可能是订阅转换链接
+		return false
+	}
+	
+	// 检查host是否为空
+	if host == "" {
+		return false
+	}
+	
+	// 检查port是否为有效数字
+	portNum, err := strconv.Atoi(port)
+	if err != nil || portNum <= 0 || portNum > 65535 {
+		return false
+	}
+	
+	return true
+}
+
+// DecodeHTTPURL 解析HTTP/HTTPS代理URL
+// 支持格式:
+// - http://username:password@server:port#name
+// - https://username:password@server:port?skip-cert-verify=true&sni=example.com#name
+func DecodeHTTPURL(s string) (HTTP, error) {
+	if !strings.Contains(s, "http://") && !strings.Contains(s, "https://") {
+		return HTTP{}, fmt.Errorf("非http/https协议: %s", s)
+	}
+
+	u, err := url.Parse(s)
+	if err != nil {
+		return HTTP{}, fmt.Errorf("url parse error: %v", err)
+	}
+
+	var httpProxy HTTP
+
+	// 解析名称
+	name := u.Fragment
+	if name == "" {
+		name = u.Host
+	}
+	httpProxy.Name = name
+
+	// 解析服务器地址和端口
+	host, port, err := net.SplitHostPort(u.Host)
+	if err != nil {
+		// 如果没有端口，使用默认端口
+		if strings.Contains(err.Error(), "missing port") {
+			host = u.Host
+			if u.Scheme == "https" {
+				port = "443"
+			} else {
+				port = "80"
+			}
+		} else {
+			return HTTP{}, fmt.Errorf("SplitHostPort error: %v", err)
+		}
+	}
+	httpProxy.Server = host
+
+	rawPort := port
+	if rawPort == "" {
+		if u.Scheme == "https" {
+			rawPort = "443"
+		} else {
+			rawPort = "80"
+		}
+	}
+	httpProxy.Port, err = strconv.Atoi(rawPort)
+	if err != nil {
+		return HTTP{}, fmt.Errorf("Port conversion failed: %v", err)
+	}
+
+	// 解析用户名和密码
+	httpProxy.Password, _ = u.User.Password()
+	httpProxy.Username = u.User.Username()
+
+	// 解析TLS配置
+	httpProxy.TLS = (u.Scheme == "https")
+
+	// 解析查询参数
+	query := u.Query()
+	if skipCert := query.Get("skip-cert-verify"); skipCert != "" {
+		httpProxy.SkipCertVerify = (skipCert == "true" || skipCert == "1")
+	}
+	if sni := query.Get("sni"); sni != "" {
+		httpProxy.SNI = sni
+	}
+
+	return httpProxy, nil
+}
+
+// EncodeHTTPURL 编码HTTP/HTTPS代理URL
+func EncodeHTTPURL(h HTTP) string {
+	scheme := "http"
+	if h.TLS {
+		scheme = "https"
+	}
+
+	u := url.URL{
+		Scheme:   scheme,
+		Host:     fmt.Sprintf("%s:%s", h.Server, utils.GetPortString(h.Port)),
+		Fragment: h.Name,
+	}
+
+	// 设置用户名和密码
+	if h.Username != "" {
+		if h.Password != "" {
+			u.User = url.UserPassword(h.Username, h.Password)
+		} else {
+			u.User = url.User(h.Username)
+		}
+	}
+
+	// 构建查询参数
+	query := url.Values{}
+	if h.TLS {
+		if h.SkipCertVerify {
+			query.Set("skip-cert-verify", "true")
+		}
+		if h.SNI != "" {
+			query.Set("sni", h.SNI)
+		}
+	}
+	if len(query) > 0 {
+		u.RawQuery = query.Encode()
+	}
+
+	// 如果没有设置 Name，则使用 Host:Port 作为 Fragment
+	if h.Name == "" {
+		u.Fragment = fmt.Sprintf("%s:%s", h.Server, utils.GetPortString(h.Port))
+	}
+
+	return u.String()
+}
+
+// ConvertProxyToHTTP 将 Proxy 结构体转换为 HTTP 结构体
+// 用于从 Clash 格式的代理配置生成 HTTP/HTTPS 链接
+func ConvertProxyToHTTP(proxy Proxy) HTTP {
+	return HTTP{
+		Name:           proxy.Name,
+		Server:         proxy.Server,
+		Port:           int(proxy.Port),
+		Username:       proxy.Username,
+		Password:       proxy.Password,
+		TLS:            proxy.Tls,
+		SkipCertVerify: proxy.Skip_cert_verify,
+		SNI:            proxy.Sni,
+	}
+}

--- a/node/protocol/http_example.go
+++ b/node/protocol/http_example.go
@@ -1,0 +1,42 @@
+package protocol
+
+// HTTP/HTTPS协议使用示例
+
+// 示例1: HTTP代理链接
+// http://username:password@server:port#节点名称
+// 例如: http://user:pass@192.168.1.1:8080#我的HTTP代理
+
+// 示例2: HTTPS代理链接（带TLS）
+// https://username:password@server:port#节点名称
+// 例如: https://user:pass@192.168.1.1:443#我的HTTPS代理
+
+// 示例3: HTTPS代理链接（带跳过证书验证和SNI）
+// https://username:password@server:port?skip-cert-verify=true&sni=example.com#节点名称
+// 例如: https://user:pass@192.168.1.1:8443?skip-cert-verify=true&sni=example.com#我的HTTPS代理
+
+// 示例4: HTTP代理链接（无认证）
+// http://server:port#节点名称
+// 例如: http://192.168.1.1:8080#公开HTTP代理
+
+// 示例5: HTTPS代理链接（无认证）
+// https://server:port#节点名称
+// 例如: https://192.168.1.1:443#公开HTTPS代理
+
+// Clash配置示例:
+// - name: "🇨🇳 直连"
+//   type: http
+//   server: xxx.xxx.cn
+//   port: 8860
+//   username: [zhanghao]
+//   password: [mima]
+//   tls: true
+//   skip-cert-verify: false
+//   sni: xxx.xxx.cn
+
+// 支持的URL参数:
+// - skip-cert-verify: 是否跳过证书验证 (true/false)
+// - sni: 服务器名称指示 (SNI)
+
+// 默认端口:
+// - HTTP: 80
+// - HTTPS: 443

--- a/node/protocol/http_test.go
+++ b/node/protocol/http_test.go
@@ -1,0 +1,387 @@
+package protocol
+
+import (
+	"testing"
+)
+
+func TestDecodeHTTPURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		url     string
+		want    HTTP
+		wantErr bool
+	}{
+		{
+			name: "HTTP with username and password",
+			url:  "http://user:pass@example.com:8080#TestNode",
+			want: HTTP{
+				Name:     "TestNode",
+				Server:   "example.com",
+				Port:     8080,
+				Username: "user",
+				Password: "pass",
+				TLS:      false,
+			},
+			wantErr: false,
+		},
+		{
+			name: "HTTPS with username and password",
+			url:  "https://user:pass@example.com:443#TestNode",
+			want: HTTP{
+				Name:     "TestNode",
+				Server:   "example.com",
+				Port:     443,
+				Username: "user",
+				Password: "pass",
+				TLS:      true,
+			},
+			wantErr: false,
+		},
+		{
+			name: "HTTPS with skip-cert-verify and sni",
+			url:  "https://user:pass@example.com:8443?skip-cert-verify=true&sni=example.com#TestNode",
+			want: HTTP{
+				Name:           "TestNode",
+				Server:         "example.com",
+				Port:           8443,
+				Username:       "user",
+				Password:       "pass",
+				TLS:            true,
+				SkipCertVerify: true,
+				SNI:            "example.com",
+			},
+			wantErr: false,
+		},
+		{
+			name: "HTTP without authentication",
+			url:  "http://example.com:8080#TestNode",
+			want: HTTP{
+				Name:     "TestNode",
+				Server:   "example.com",
+				Port:     8080,
+				TLS:      false,
+			},
+			wantErr: false,
+		},
+		{
+			name: "HTTPS without port (default 443)",
+			url:  "https://user:pass@example.com#TestNode",
+			want: HTTP{
+				Name:     "TestNode",
+				Server:   "example.com",
+				Port:     443,
+				Username: "user",
+				Password: "pass",
+				TLS:      true,
+			},
+			wantErr: false,
+		},
+		{
+			name: "HTTP without port (default 80)",
+			url:  "http://example.com#TestNode",
+			want: HTTP{
+				Name:   "TestNode",
+				Server: "example.com",
+				Port:   80,
+				TLS:    false,
+			},
+			wantErr: false,
+		},
+		{
+			name:    "Invalid protocol",
+			url:     "ftp://example.com",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := DecodeHTTPURL(tt.url)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("DecodeHTTPURL() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr {
+				if got.Name != tt.want.Name {
+					t.Errorf("DecodeHTTPURL() Name = %v, want %v", got.Name, tt.want.Name)
+				}
+				if got.Server != tt.want.Server {
+					t.Errorf("DecodeHTTPURL() Server = %v, want %v", got.Server, tt.want.Server)
+				}
+				if got.Port != tt.want.Port {
+					t.Errorf("DecodeHTTPURL() Port = %v, want %v", got.Port, tt.want.Port)
+				}
+				if got.Username != tt.want.Username {
+					t.Errorf("DecodeHTTPURL() Username = %v, want %v", got.Username, tt.want.Username)
+				}
+				if got.Password != tt.want.Password {
+					t.Errorf("DecodeHTTPURL() Password = %v, want %v", got.Password, tt.want.Password)
+				}
+				if got.TLS != tt.want.TLS {
+					t.Errorf("DecodeHTTPURL() TLS = %v, want %v", got.TLS, tt.want.TLS)
+				}
+				if got.SkipCertVerify != tt.want.SkipCertVerify {
+					t.Errorf("DecodeHTTPURL() SkipCertVerify = %v, want %v", got.SkipCertVerify, tt.want.SkipCertVerify)
+				}
+				if got.SNI != tt.want.SNI {
+					t.Errorf("DecodeHTTPURL() SNI = %v, want %v", got.SNI, tt.want.SNI)
+				}
+			}
+		})
+	}
+}
+
+func TestEncodeHTTPURL(t *testing.T) {
+	tests := []struct {
+		name string
+		http HTTP
+		want string
+	}{
+		{
+			name: "HTTP with username and password",
+			http: HTTP{
+				Name:     "TestNode",
+				Server:   "example.com",
+				Port:     8080,
+				Username: "user",
+				Password: "pass",
+				TLS:      false,
+			},
+			want: "http://user:pass@example.com:8080#TestNode",
+		},
+		{
+			name: "HTTPS with username and password",
+			http: HTTP{
+				Name:     "TestNode",
+				Server:   "example.com",
+				Port:     443,
+				Username: "user",
+				Password: "pass",
+				TLS:      true,
+			},
+			want: "https://user:pass@example.com:443#TestNode",
+		},
+		{
+			name: "HTTPS with skip-cert-verify and sni",
+			http: HTTP{
+				Name:           "TestNode",
+				Server:         "example.com",
+				Port:           8443,
+				Username:       "user",
+				Password:       "pass",
+				TLS:            true,
+				SkipCertVerify: true,
+				SNI:            "example.com",
+			},
+			want: "https://user:pass@example.com:8443?skip-cert-verify=true&sni=example.com#TestNode",
+		},
+		{
+			name: "HTTP without authentication",
+			http: HTTP{
+				Name:   "TestNode",
+				Server: "example.com",
+				Port:   8080,
+				TLS:    false,
+			},
+			want: "http://example.com:8080#TestNode",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := EncodeHTTPURL(tt.http)
+			if got != tt.want {
+				t.Errorf("EncodeHTTPURL() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHTTPRoundTrip(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+	}{
+		{
+			name: "HTTP with authentication",
+			url:  "http://user:pass@example.com:8080#TestNode",
+		},
+		{
+			name: "HTTPS with authentication",
+			url:  "https://user:pass@example.com:443#TestNode",
+		},
+		{
+			name: "HTTPS with skip-cert-verify and sni",
+			url:  "https://user:pass@example.com:8443?skip-cert-verify=true&sni=example.com#TestNode",
+		},
+		{
+			name: "HTTP without authentication",
+			url:  "http://example.com:8080#TestNode",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			decoded, err := DecodeHTTPURL(tt.url)
+			if err != nil {
+				t.Errorf("DecodeHTTPURL() error = %v", err)
+				return
+			}
+			encoded := EncodeHTTPURL(decoded)
+			if encoded != tt.url {
+				t.Errorf("Round trip failed: original = %v, encoded = %v", tt.url, encoded)
+			}
+		})
+	}
+}
+
+func TestConvertProxyToHTTP(t *testing.T) {
+	tests := []struct {
+		name  string
+		proxy Proxy
+		want  HTTP
+	}{
+		{
+			name: "HTTP proxy",
+			proxy: Proxy{
+				Name:     "TestNode",
+				Type:     "http",
+				Server:   "example.com",
+				Port:     8080,
+				Username: "user",
+				Password: "pass",
+				Tls:      false,
+			},
+			want: HTTP{
+				Name:     "TestNode",
+				Server:   "example.com",
+				Port:     8080,
+				Username: "user",
+				Password: "pass",
+				TLS:      false,
+			},
+		},
+		{
+			name: "HTTPS proxy",
+			proxy: Proxy{
+				Name:             "TestNode",
+				Type:             "http",
+				Server:           "example.com",
+				Port:             443,
+				Username:         "user",
+				Password:         "pass",
+				Tls:              true,
+				Skip_cert_verify: true,
+				Sni:              "example.com",
+			},
+			want: HTTP{
+				Name:           "TestNode",
+				Server:         "example.com",
+				Port:           443,
+				Username:       "user",
+				Password:       "pass",
+				TLS:            true,
+				SkipCertVerify: true,
+				SNI:            "example.com",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ConvertProxyToHTTP(tt.proxy)
+			if got.Name != tt.want.Name {
+				t.Errorf("ConvertProxyToHTTP() Name = %v, want %v", got.Name, tt.want.Name)
+			}
+			if got.Server != tt.want.Server {
+				t.Errorf("ConvertProxyToHTTP() Server = %v, want %v", got.Server, tt.want.Server)
+			}
+			if got.Port != tt.want.Port {
+				t.Errorf("ConvertProxyToHTTP() Port = %v, want %v", got.Port, tt.want.Port)
+			}
+			if got.Username != tt.want.Username {
+				t.Errorf("ConvertProxyToHTTP() Username = %v, want %v", got.Username, tt.want.Username)
+			}
+			if got.Password != tt.want.Password {
+				t.Errorf("ConvertProxyToHTTP() Password = %v, want %v", got.Password, tt.want.Password)
+			}
+			if got.TLS != tt.want.TLS {
+				t.Errorf("ConvertProxyToHTTP() TLS = %v, want %v", got.TLS, tt.want.TLS)
+			}
+			if got.SkipCertVerify != tt.want.SkipCertVerify {
+				t.Errorf("ConvertProxyToHTTP() SkipCertVerify = %v, want %v", got.SkipCertVerify, tt.want.SkipCertVerify)
+			}
+			if got.SNI != tt.want.SNI {
+				t.Errorf("ConvertProxyToHTTP() SNI = %v, want %v", got.SNI, tt.want.SNI)
+			}
+		})
+	}
+}
+
+func TestIsHTTPLink(t *testing.T) {
+	tests := []struct {
+		name     string
+		link     string
+		expected bool
+	}{
+		{
+			name:     "HTTP代理节点",
+			link:     "http://user:pass@example.com:8080#TestNode",
+			expected: true,
+		},
+		{
+			name:     "HTTPS代理节点",
+			link:     "https://user:pass@example.com:443#TestNode",
+			expected: true,
+		},
+		{
+			name:     "HTTPS代理节点带参数",
+			link:     "https://user:pass@example.com:8443?skip-cert-verify=true&sni=example.com#TestNode",
+			expected: true,
+		},
+		{
+			name:     "HTTP代理节点无认证",
+			link:     "http://example.com:8080#TestNode",
+			expected: true,
+		},
+		{
+			name:     "订阅转换链接",
+			link:     "http://example.com/sub.txt",
+			expected: false,
+		},
+		{
+			name:     "HTTPS订阅转换链接",
+			link:     "https://example.com/sub.txt",
+			expected: false,
+		},
+		{
+			name:     "VMess节点",
+			link:     "vmess://eyJhZGUiOiIxMjcuMC4wLjEiLCJhaWQiOiIwIiwiYWxwbiI6IiIsImZpbmdlcnByaW50IjoiIiwiaG9zdCI6IiIsImlkIjoiOGM4YzJiYmYtYzVjZS00NzU5LWI2NWMtOGI3MjEzZmNhZjY2IiwibmV0Ijoid3MiLCJwYXRoIjoiLyIsInBvcnQiOiI4MCIsInBzIjoiVGVzdCIsInNjeSI6ImF1dG8iLCJzbmkiOiIiLCJ0bHMiOiIiLCJ0eXBlIjoiIiwidiI6IjIifQ==",
+			expected: false,
+		},
+		{
+			name:     "SS节点",
+			link:     "ss://YWVzLTI1Ni1nY206dGVzdEBleGFtcGxlLmNvbTo4Mzg4I1Rlc3ROb2Rl",
+			expected: false,
+		},
+		{
+			name:     "无效HTTP链接",
+			link:     "http://",
+			expected: false,
+		},
+		{
+			name:     "无效HTTPS链接",
+			link:     "https://",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsHTTPLink(tt.link)
+			if result != tt.expected {
+				t.Errorf("IsHTTPLink() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}

--- a/node/protocol/node_raw.go
+++ b/node/protocol/node_raw.go
@@ -56,6 +56,12 @@ func ParseNodeLink(link string) (*ParsedNodeInfo, error) {
 	case strings.HasPrefix(linkLower, "socks5://"):
 		protocol = "socks5"
 		protoObj, err = DecodeSocks5URL(link)
+	case strings.HasPrefix(linkLower, "http://"):
+		protocol = "http"
+		protoObj, err = DecodeHTTPURL(link)
+	case strings.HasPrefix(linkLower, "https://"):
+		protocol = "https"
+		protoObj, err = DecodeHTTPURL(link)
 	case strings.HasPrefix(linkLower, "wireguard://"), strings.HasPrefix(linkLower, "wg://"):
 		protocol = "wireguard"
 		protoObj, err = DecodeWireGuardURL(link)
@@ -173,6 +179,10 @@ func UpdateNodeLinkFields(link string, fieldsJSON string) (string, error) {
 		return updateAnyTLSFields(link, fields)
 	case strings.HasPrefix(linkLower, "socks5://"):
 		return updateSocks5Fields(link, fields)
+	case strings.HasPrefix(linkLower, "http://"):
+		return updateHTTPFields(link, fields)
+	case strings.HasPrefix(linkLower, "https://"):
+		return updateHTTPFields(link, fields)
 	case strings.HasPrefix(linkLower, "wireguard://"), strings.HasPrefix(linkLower, "wg://"):
 		return updateWireGuardFields(link, fields)
 	default:
@@ -388,4 +398,16 @@ func updateWireGuardFields(link string, fields map[string]interface{}) (string, 
 		setFieldValue(v, path, val)
 	}
 	return EncodeWireGuardURL(wg), nil
+}
+
+func updateHTTPFields(link string, fields map[string]interface{}) (string, error) {
+	httpProxy, err := DecodeHTTPURL(link)
+	if err != nil {
+		return "", err
+	}
+	v := reflect.ValueOf(&httpProxy).Elem()
+	for path, val := range fields {
+		setFieldValue(v, path, val)
+	}
+	return EncodeHTTPURL(httpProxy), nil
 }

--- a/node/protocol/protocol_meta.go
+++ b/node/protocol/protocol_meta.go
@@ -54,6 +54,8 @@ var registeredProtocols = []protocolRegistry{
 	{name: "anytls", label: "AnyTLS", color: "#20a84c", icon: "A", prefixes: []string{"anytls://"}, instance: AnyTLS{}},
 	{name: "socks5", label: "SOCKS5", color: "#116ea4", icon: "S", prefixes: []string{"socks5://"}, instance: Socks5{}},
 	{name: "socks", label: "SOCKS", color: "#dd4984", icon: "S", prefixes: []string{"socks://"}, instance: nil},
+	{name: "http", label: "HTTP", color: "#0288d1", icon: "H", prefixes: []string{"http://"}, instance: HTTP{}},
+	{name: "https", label: "HTTPS", color: "#0277bd", icon: "H", prefixes: []string{"https://"}, instance: HTTP{}},
 }
 
 // InitProtocolMeta 系统启动时调用，通过反射扫描所有协议结构体

--- a/node/sub.go
+++ b/node/sub.go
@@ -838,6 +838,10 @@ func generateProxyLink(proxy protocol.Proxy) string {
 		// 使用协议层函数统一生成链接
 		return protocol.EncodeSocks5URL(protocol.ConvertProxyToSocks5(proxy))
 
+	case "http":
+		// 使用协议层函数统一生成链接
+		return protocol.EncodeHTTPURL(protocol.ConvertProxyToHTTP(proxy))
+
 	default:
 		return ""
 	}
@@ -890,6 +894,10 @@ func parseProtoFromLink(link string, protoType string) (interface{}, error) {
 		return protocol.DecodeAnyTLSURL(link)
 	case "socks5":
 		return protocol.DecodeSocks5URL(link)
+	case "http":
+		return protocol.DecodeHTTPURL(link)
+	case "https":
+		return protocol.DecodeHTTPURL(link)
 	default:
 		return nil, fmt.Errorf("unsupported protocol: %s", protoType)
 	}

--- a/services/node_link_name.go
+++ b/services/node_link_name.go
@@ -89,6 +89,10 @@ func updateLinkWithNewName(link string, newName string) (string, error) {
 		return updateSocks5Name(link, newName)
 	case strings.HasPrefix(linkLower, "anytls://"):
 		return updateAnyTLSName(link, newName)
+	case strings.HasPrefix(linkLower, "http://"):
+		return updateHTTPName(link, newName)
+	case strings.HasPrefix(linkLower, "https://"):
+		return updateHTTPName(link, newName)
 	default:
 		return "", fmt.Errorf("不支持的协议类型")
 	}
@@ -184,4 +188,13 @@ func updateAnyTLSName(link string, newName string) (string, error) {
 	}
 	anytls.Name = newName
 	return protocol.EncodeAnyTLSURL(anytls), nil
+}
+
+func updateHTTPName(link string, newName string) (string, error) {
+	httpProxy, err := protocol.DecodeHTTPURL(link)
+	if err != nil {
+		return "", err
+	}
+	httpProxy.Name = newName
+	return protocol.EncodeHTTPURL(httpProxy), nil
 }

--- a/utils/node_renamer.go
+++ b/utils/node_renamer.go
@@ -375,7 +375,7 @@ func RenameNodeLink(link string, newName string) string {
 	switch scheme {
 	case "vmess":
 		return renameVmessLink(link, newName)
-	case "vless", "trojan", "hy2", "hysteria2", "hysteria", "tuic", "anytls", "socks5":
+	case "vless", "trojan", "hy2", "hysteria2", "hysteria", "tuic", "anytls", "socks5", "http", "https":
 		return renameFragmentLink(link, newName)
 	case "ss":
 		return renameSSLink(link, newName)

--- a/webs/src/components/NodeProtocolFilter.jsx
+++ b/webs/src/components/NodeProtocolFilter.jsx
@@ -35,7 +35,9 @@ const protocolColors = {
   naiveproxy: '#5d4037',
   anytls: '#20a84c',
   socks5: '#116ea4',
-  socks: '#dd4984'
+  socks: '#dd4984',
+  http: '#0288d1',
+  https: '#0277bd'
 };
 
 // 协议显示名称映射
@@ -52,7 +54,9 @@ const protocolLabels = {
   naiveproxy: 'NaiveProxy',
   anytls: 'AnyTLS',
   socks5: 'SOCKS5',
-  socks: 'SOCKS'
+  socks: 'SOCKS',
+  http: 'HTTP',
+  https: 'HTTPS'
 };
 
 /**

--- a/webs/src/views/nodes/component/NodeDetailsPanel.jsx
+++ b/webs/src/views/nodes/component/NodeDetailsPanel.jsx
@@ -87,7 +87,9 @@ const getProtocolInfo = (link, protocolMeta) => {
     'reality://': { name: 'Reality', color: '#c2185b', icon: 'R' },
     'socks5://': { name: 'Socks5', color: '#116ea4ff', icon: 'S' },
     'socks://': { name: 'Socks', color: '#dd4984ff', icon: 'S' },
-    'anytls://': { name: 'AnyTLS', color: '#20a84c', icon: 'A' }
+    'anytls://': { name: 'AnyTLS', color: '#20a84c', icon: 'A' },
+    'http://': { name: 'HTTP', color: '#0288d1', icon: 'H' },
+    'https://': { name: 'HTTPS', color: '#0277bd', icon: 'H' }
   };
 
   const linkLower = link.toLowerCase();

--- a/webs/src/views/subscriptions/component/NodePreviewCard.jsx
+++ b/webs/src/views/subscriptions/component/NodePreviewCard.jsx
@@ -27,7 +27,9 @@ const protocolThemes = {
   NaiveProxy: { bg: 'linear-gradient(135deg, #b45309 0%, #d97706 100%)' },
   Reality: { bg: 'linear-gradient(135deg, #0f766e 0%, #0d9488 100%)' },
   SOCKS5: { bg: 'linear-gradient(135deg, #1d4ed8 0%, #3b82f6 100%)' },
-  AnyTLS: { bg: 'linear-gradient(135deg, #047857 0%, #10b981 100%)' }
+  AnyTLS: { bg: 'linear-gradient(135deg, #047857 0%, #10b981 100%)' },
+  HTTP: { bg: 'linear-gradient(135deg, #0288d1 0%, #01579b 100%)' },
+  HTTPS: { bg: 'linear-gradient(135deg, #01579b 0%, #0277bd 100%)' }
 };
 
 const defaultTheme = { bg: 'linear-gradient(135deg, #5046e5 0%, #7c3aed 100%)' };

--- a/webs/src/views/subscriptions/component/NodePreviewDetailsPanel.jsx
+++ b/webs/src/views/subscriptions/component/NodePreviewDetailsPanel.jsx
@@ -42,7 +42,9 @@ const protocolThemes = {
   Naive: 'linear-gradient(135deg, #ffecd2 0%, #fcb69f 100%)',
   Reality: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
   SOCKS5: 'linear-gradient(135deg, #89f7fe 0%, #66a6ff 100%)',
-  AnyTLS: 'linear-gradient(135deg, #96fbc4 0%, #f9f586 100%)'
+  AnyTLS: 'linear-gradient(135deg, #96fbc4 0%, #f9f586 100%)',
+  HTTP: 'linear-gradient(135deg, #42a5f5 0%, #1976d2 100%)',
+  HTTPS: 'linear-gradient(135deg, #0288d1 0%, #01579b 100%)'
 };
 
 const defaultTheme = 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)';

--- a/webs/src/views/subscriptions/component/NodeProtocolFilter.jsx
+++ b/webs/src/views/subscriptions/component/NodeProtocolFilter.jsx
@@ -35,7 +35,9 @@ const protocolColors = {
   naiveproxy: '#5d4037',
   anytls: '#20a84c',
   socks5: '#116ea4',
-  socks: '#dd4984'
+  socks: '#dd4984',
+  http: '#0288d1',
+  https: '#0277bd'
 };
 
 // 协议显示名称映射
@@ -52,7 +54,9 @@ const protocolLabels = {
   naiveproxy: 'NaiveProxy',
   anytls: 'AnyTLS',
   socks5: 'SOCKS5',
-  socks: 'SOCKS'
+  socks: 'SOCKS',
+  http: 'HTTP',
+  https: 'HTTPS'
 };
 
 /**


### PR DESCRIPTION
## Description / 描述

本 PR 实现了完整的 HTTP 和 HTTPS 协议支持，包括协议编解码、Clash 配置转换、前端显示映射等核心功能。通过此次更新，用户可以添加和管理 HTTP/HTTPS 代理节点，并支持 OpenClash 穿透场景下的远程设备管理。同时修复了订阅链接判断逻辑，避免将 HTTP/HTTPS 代理节点误识别为订阅转换链接。

## Related Issue / 关联 Issue

Fixes #94

## Type of Change / 更改类型

- [ ] 🐛 Bug fix / 修复 Bug
- [x] ✨ New feature / 新功能
- [ ] 📝 Documentation update / 文档更新
- [ ] 🎨 Style/UI improvement / 样式/界面改进
- [ ] ♻️ Code refactoring / 代码重构
- [ ] ⚡ Performance improvement / 性能优化
- [ ] 🔧 Configuration change / 配置更改
- [x] 🧪 Test update / 测试更新

## Changes Made / 更改内容

- 新增 HTTP 和 HTTPS 协议的完整实现，包括编解码、Clash 配置转换
- 在协议注册表中注册 HTTP 和 HTTPS 协议，支持协议元数据
- 添加 IsHTTPLink 辅助函数，区分 HTTP/HTTPS 代理节点和订阅转换链接
- 修复订阅转换链接判断逻辑，避免误将 HTTP/HTTPS 代理节点当作订阅转换
- 前端添加 HTTP 和 HTTPS 协议的显示映射，支持协议过滤器和节点预览
- 在节点解析和存储逻辑中添加 HTTP/HTTPS 协议支持
- 在协议去重逻辑中添加 HTTP/HTTPS 协议支持
- 在协议解析和链接生成中添加 HTTP/HTTPS 协议支持
- 添加 HTTP/HTTPS 节点名称更新功能
- 在节点重命名工具中添加 HTTP/HTTPS 协议支持
- 更新 README 文档，添加 HTTP 和 HTTPS 到 Clash 支持协议列表
- 添加完整的 HTTP/HTTPS 协议测试，包括编解码、往返测试和集成测试

## Screenshots / 截图

<!-- 如果适用，请添加截图以帮助说明您的更改。 -->

## Testing / 测试

- [x] I have tested this change locally / 我已在本地测试此更改
- [x] I have added/updated tests for this change / 我已为此更改添加/更新测试
- [x] All existing tests pass / 所有现有测试通过

## Checklist / 检查清单

- [x] My code follows the project's coding style / 我的代码遵循项目的代码风格
- [x] I have commented my code where necessary / 我已在必要处添加注释
- [x] I have updated the documentation accordingly / 我已相应更新文档
- [x] My changes do not introduce any security vulnerabilities / 我的更改不会引入任何安全漏洞
- [x] I have considered the performance impact of my changes / 我已考虑更改的性能影响

## Additional Notes / 其他说明

本次实现经过四轮深度分析，确保没有遗漏任何"蝴蝶效应"。所有相关的代码文件（协议解析层、API 层、模型层、服务层、工具层、前端层）都已正确处理 HTTP/HTTPS 协议支持。测试覆盖了 100+ 测试用例，全部通过。