### PR TITLE
fix: support multiline IP whitelist entries

### DIFF
--- a/utils/common.go
+++ b/utils/common.go
@@ -239,26 +239,57 @@ func RandString(number int) string {
 	return Secret
 }
 
+func splitIPEntries(ipString string) []string {
+	fields := strings.FieldsFunc(ipString, func(r rune) bool {
+		return r == ',' || r == '\n' || r == '\r'
+	})
+
+	entries := make([]string, 0, len(fields))
+	for _, field := range fields {
+		entry := strings.TrimSpace(field)
+		if entry != "" {
+			entries = append(entries, entry)
+		}
+	}
+
+	return entries
+}
+
 // IsIpInCidr 判断IP是否在CIDR范围内
 func IsIpInCidr(cIP string, sIP string) bool {
-	ips := strings.Split(sIP, ",")
-	for _, ip := range ips {
+	clientIP := net.ParseIP(strings.TrimSpace(cIP))
+	if clientIP == nil {
+		return false
+	}
+
+	for _, ip := range splitIPEntries(sIP) {
 		if strings.Contains(ip, "/") {
 			_, ipNet, err := net.ParseCIDR(ip)
 			if err != nil {
-				return false
+				continue
 			}
-			return ipNet.Contains(net.ParseIP(cIP))
-		} else {
-			return ip == cIP
+			if ipNet.Contains(clientIP) {
+				return true
+			}
+			continue
+		}
+
+		parsedIP := net.ParseIP(ip)
+		if parsedIP != nil && parsedIP.Equal(clientIP) {
+			return true
 		}
 	}
+
 	return false
 }
 
 // IpFormatValidation IP格式检测
 func IpFormatValidation(ipString string) bool {
-	ips := strings.Split(ipString, ",")
+	ips := splitIPEntries(ipString)
+	if len(ips) == 0 {
+		return strings.TrimSpace(ipString) == ""
+	}
+
 	for _, ip := range ips {
 		_, _, err := net.ParseCIDR(ip)
 		if err != nil {

--- a/utils/common_test.go
+++ b/utils/common_test.go
@@ -1,0 +1,43 @@
+package utils
+
+import "testing"
+
+func TestIpFormatValidationAcceptsMultilineEntries(t *testing.T) {
+	input := "192.168.0.0/16\r\n10.10.2.0/24"
+
+	if !IpFormatValidation(input) {
+		t.Fatalf("expected multiline CIDR list to be valid")
+	}
+}
+
+func TestIpFormatValidationRejectsInvalidEntry(t *testing.T) {
+	input := "192.168.0.0/16\nnot-an-ip"
+
+	if IpFormatValidation(input) {
+		t.Fatalf("expected invalid IP list to be rejected")
+	}
+}
+
+func TestIsIpInCidrChecksAllEntries(t *testing.T) {
+	allowList := "192.168.0.0/16\n10.10.2.0/24"
+
+	if !IsIpInCidr("10.10.2.15", allowList) {
+		t.Fatalf("expected IP to match the second allow-list entry")
+	}
+
+	if IsIpInCidr("10.10.3.15", allowList) {
+		t.Fatalf("expected IP outside all ranges to be rejected")
+	}
+}
+
+func TestIsIpInCidrSupportsExactIPsAndCommaSeparatedEntries(t *testing.T) {
+	allowList := "192.168.1.10, 10.10.2.0/24"
+
+	if !IsIpInCidr("192.168.1.10", allowList) {
+		t.Fatalf("expected exact IP match to be allowed")
+	}
+
+	if !IsIpInCidr("10.10.2.42", allowList) {
+		t.Fatalf("expected CIDR match to be allowed")
+	}
+}


### PR DESCRIPTION
## Summary 

accept newline-separated IP/CIDR entries in whitelist and blacklist validation:
- check every IP/CIDR entry when enforcing subscription IP access rules
- add regression tests for multiline input and multi-entry matching

Fixes #129