### PR TITLE
fix(protocol): support plain SIP002 SS userinfo for ss2022 URLTest

### DIFF
--- a/node/protocol/ss.go
+++ b/node/protocol/ss.go
@@ -89,6 +89,26 @@ func parseSSURL(s string) (auth, addr, name string, plugin SsPlugin) {
 	return auth, addr, name, plugin
 }
 
+func decodeSSAuth(auth string) (string, error) {
+	if auth == "" {
+		return "", fmt.Errorf("missing SS auth")
+	}
+
+	if decoded := utils.Base64Decode(auth); decoded != auth && strings.Contains(decoded, ":") {
+		return decoded, nil
+	}
+
+	unescaped, err := url.PathUnescape(auth)
+	if err != nil {
+		return "", fmt.Errorf("unescape SS auth: %w", err)
+	}
+	if strings.Contains(unescaped, ":") {
+		return unescaped, nil
+	}
+
+	return "", fmt.Errorf("invalid SS auth")
+}
+
 // parseSSPlugin 解析 SIP002 格式的 plugin 参数
 // 格式: plugin_name;opt1=val1;opt2=val2
 // 特殊字符需要反斜杠转义
@@ -278,9 +298,9 @@ func DecodeSSURL(s string) (Ss, error) {
 	// 解析ss链接
 	param, addr, name, plugin := parseSSURL(s)
 	// base64解码
-	param = utils.Base64Decode(param)
+	param, err := decodeSSAuth(param)
 	// 判断是否为空
-	if param == "" || addr == "" {
+	if err != nil || param == "" || addr == "" {
 		return Ss{}, fmt.Errorf("invalid SS URL")
 	}
 	// 解析参数
@@ -295,7 +315,7 @@ func DecodeSSURL(s string) (Ss, error) {
 	}
 	// 开发环境输出结果
 	if utils.CheckEnvironment() {
-		fmt.Println("Param:", utils.Base64Decode(param))
+		fmt.Println("Param:", param)
 		fmt.Println("Server", server)
 		fmt.Println("Port", port)
 		fmt.Println("Name:", name)

--- a/node/protocol/ss_plain_userinfo_test.go
+++ b/node/protocol/ss_plain_userinfo_test.go
@@ -1,0 +1,33 @@
+package protocol
+
+import "testing"
+
+func TestDecodeSSURLWithPlainUserinfo(t *testing.T) {
+	url := "ss://2022-blake3-aes-128-gcm:%2FS8blFRGE3o%2FaDSN93iTmA%3D%3D@3.115.244.62:18898#JP-AWS"
+
+	ss, err := DecodeSSURL(url)
+	if err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+
+	assertEqualString(t, "Server", "3.115.244.62", ss.Server)
+	assertEqualIntInterface(t, "Port", 18898, ss.Port)
+	assertEqualString(t, "Cipher", "2022-blake3-aes-128-gcm", ss.Param.Cipher)
+	assertEqualString(t, "Password", "/S8blFRGE3o/aDSN93iTmA==", ss.Param.Password)
+	assertEqualString(t, "Name", "JP-AWS", ss.Name)
+}
+
+func TestDecodeSSURLWithPlainUserinfoContainingColon(t *testing.T) {
+	url := "ss://2022-blake3-aes-256-gcm:n3RRAL3KF%2FzeWa1O722wd9UlNR%2BGVgSEgjeujdImVds%3D%3AH9jQ%2B6AabhJDhnu6NeuIk4IaGjNEnTj2TxzXQ9Sg9lI%3D@3.115.244.62:40000#US-Hawaii-AWS"
+
+	ss, err := DecodeSSURL(url)
+	if err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+
+	assertEqualString(t, "Server", "3.115.244.62", ss.Server)
+	assertEqualIntInterface(t, "Port", 40000, ss.Port)
+	assertEqualString(t, "Cipher", "2022-blake3-aes-256-gcm", ss.Param.Cipher)
+	assertEqualString(t, "Password", "n3RRAL3KF/zeWa1O722wd9UlNR+GVgSEgjeujdImVds=:H9jQ+6AabhJDhnu6NeuIk4IaGjNEnTj2TxzXQ9Sg9lI=", ss.Param.Password)
+	assertEqualString(t, "Name", "US-Hawaii-AWS", ss.Name)
+}


### PR DESCRIPTION
## Summary
This PR is now rebased onto the latest `main` (`01b50b6`) and only keeps the SS parsing fix.

It addresses two user-visible problems that share the same root cause:

1. Valid SIP002 SS links using plain URI-escaped `userinfo` fail to parse.
2. Affected `ss2022` nodes then fail latency / URL tests, which makes them look like Mihomo does not support those links.

## Root Cause
`DecodeSSURL` currently does an unconditional base64 decode on `userinfo` before splitting `cipher:password`:

- legacy form that still works today: `ss://base64(cipher:password)@host:port`
- plain SIP002 form that currently breaks: `ss://cipher:password@host:port`

For the plain SIP002 form, the current code decodes the already-plain `userinfo` again, so valid links such as `ss://2022-blake3-aes-256-gcm:...@host:port` are rejected before Mihomo ever gets a usable adapter.

In practice that shows up as two symptoms:

- node import / decode fails for valid plain-userinfo SS links
- Mihomo `URLTest` / latency test fails for those same `ss2022` nodes, not because Mihomo necessarily lacks `ss2022` support, but because the adapter creation path already failed in SublinkPro

## Fix
- add `decodeSSAuth` to accept both SS auth encodings:
  - legacy base64 `userinfo`
  - plain URI-escaped `cipher:password` `userinfo`
- keep the previous base64 path unchanged when the auth really is base64
- correctly `PathUnescape` plain `userinfo`, so reserved characters are preserved
- keep passwords containing embedded colons intact after splitting only on the first colon

## Tests
- add regression coverage for plain SIP002 `userinfo`
- add regression coverage for a password that itself contains a colon, which is common in `ss2022` material
- `go test ./node/protocol`

## Manual Validation On Latest Main
I reproduced this on the latest `main` first, then re-tested with this patch.

On the latest unpatched `main`, previously failing `ss2022` sample links still timed out in real Mihomo URL tests because adapter creation failed first.

After applying this patch on top of the latest `main`, the same `ss2022` samples passed URL testing successfully.
