### PR TITLE
fix: handle node fields meta response in dedup config

### DIFF
--- a/webs/src/views/subscriptions/component/DeduplicationConfig.jsx
+++ b/webs/src/views/subscriptions/component/DeduplicationConfig.jsx
@@ -47,7 +47,7 @@ function DeduplicationConfig({ value, onChange }) {
         setLoading(true);
         const [protoRes, nodeRes] = await Promise.all([getProtocolMeta(), getNodeFieldsMeta()]);
         setProtocolMeta(protoRes.data || []);
-        setNodeFieldsMeta(nodeRes.data || []);
+        setNodeFieldsMeta(nodeRes.data?.fields || []);
         setError(null);
       } catch (err) {
         setError('加载元数据失败');


### PR DESCRIPTION
## Description / 描述

Fix a frontend data handling bug in the subscription deduplication config dialog.

修复订阅去重配置面板中的前端数据处理问题。

When clicking the "通用字段去重" option, the frontend treated the `node-fields-meta` API response as an array, while the backend actually returns an object containing `fields` and `conditionFields`. This caused the dedup config UI to fail. The change updates the component to read `data.fields` correctly.

点击“通用字段去重”时，前端将 `node-fields-meta` 接口返回值错误地当作数组处理，而后端实际返回的是包含 `fields` 和 `conditionFields` 的对象，导致去重配置界面报错。本次修改将组件改为正确读取 `data.fields`。

## Related Issue / 关联 Issue

Fixes #
Related to #

## Type of Change / 更改类型

- [x] 🐛 Bug fix / 修复 Bug
- [ ] ✨ New feature / 新功能
- [ ] 📝 Documentation update / 文档更新
- [ ] 🎨 Style/UI improvement / 样式/界面改进
- [ ] ♻️ Code refactoring / 代码重构
- [ ] ⚡ Performance improvement / 性能优化
- [ ] 🔧 Configuration change / 配置更改
- [ ] 🧪 Test update / 测试更新

## Changes Made / 更改内容

- Fixed `DeduplicationConfig` to read `getNodeFieldsMeta()` response from `data.fields` instead of treating `data` as an array
- Verified the backend API response shape and confirmed no backend change was required
- Validated the frontend change with local build and lint checks

## Screenshots / 截图

https://github.com/user-attachments/assets/8d0e04df-e6fb-4b9d-a2ed-8fc5514b2783


## Testing / 测试

- [x] I have tested this change locally / 我已在本地测试此更改
- [ ] I have added/updated tests for this change / 我已为此更改添加/更新测试
- [x] All existing tests pass / 所有现有测试通过

Validation performed:
- `yarn run build`
- `yarn run lint`

## Checklist / 检查清单

- [x] My code follows the project's coding style / 我的代码遵循项目的代码风格
- [ ] I have commented my code where necessary / 我已在必要处添加注释
- [ ] I have updated the documentation accordingly / 我已相应更新文档
- [x] My changes do not introduce any security vulnerabilities / 我的更改不会引入任何安全漏洞
- [x] I have considered the performance impact of my changes / 我已考虑更改的性能影响

## Additional Notes / 其他说明

No backend or documentation update was needed for this change.

本次修改仅涉及前端对既有接口返回结构的正确消费，后端接口语义未变化，因此无需同步修改后端或文档。
