### PR TITLE
fix(surge): reuse shared node rename info

### DIFF
--- a/api/clients.go
+++ b/api/clients.go
@@ -423,31 +423,11 @@ func resolveClashDialerProxy(node models.Node, finalNodeName string, chainNodeDi
 	return normalizeDialerProxyName(dialerProxy, dialerProxyNameMap)
 }
 
-func buildSurgeRenameInfo(node models.Node, processedLinkName, link string, index int) utils.NodeInfo {
-	return utils.NodeInfo{
-		Name:          node.EffectiveName(),
-		LinkName:      processedLinkName,
-		LinkCountry:   node.LinkCountry,
-		Speed:         node.Speed,
-		SpeedStatus:   node.SpeedStatus,
-		DelayTime:     node.DelayTime,
-		DelayStatus:   node.DelayStatus,
-		Group:         node.Group,
-		Source:        node.Source,
-		Index:         index,
-		Protocol:      protocol.GetProtocolFromLink(link),
-		Tags:          node.Tags,
-		IsBroadcast:   node.IsBroadcast,
-		IsResidential: node.IsResidential,
-		FraudScore:    node.FraudScore,
-	}
-}
-
 func buildSurgeRenamedNodeLink(node models.Node, processedLinkName, nodeNameRule, link string, index int) string {
 	if nodeNameRule == "" {
 		return utils.RenameNodeLink(link, node.EffectiveName())
 	}
-	newName := utils.RenameNode(nodeNameRule, buildSurgeRenameInfo(node, processedLinkName, link, index))
+	newName := utils.RenameNode(nodeNameRule, models.BuildNodeRenameInfo(node, processedLinkName, protocol.GetProtocolFromLink(link), index))
 	return utils.RenameNodeLink(link, newName)
 }
 

--- a/api/clients_test.go
+++ b/api/clients_test.go
@@ -361,6 +361,33 @@ func TestResolveClashDialerProxyPrefersChainTargetOverStoredName(t *testing.T) {
 	}
 }
 
+func TestBuildSurgeRenamedNodeLinkUsesQualityStatusFields(t *testing.T) {
+	utils.SetProtocolLinkFuncs(protocol.GetProtocolLabelFromLink, protocol.RenameNodeLink)
+	t.Cleanup(func() {
+		utils.SetProtocolLinkFuncs(nil, nil)
+	})
+
+	node := models.Node{
+		Name:          "origin-name",
+		LinkName:      "origin-name",
+		Link:          "ss://YWVzLTEyOC1nY206cGFzc0BleGFtcGxlLmNvbTo0NDM=#origin-name",
+		LinkCountry:   "US",
+		Source:        "[BK]",
+		Speed:         1.25,
+		SpeedStatus:   "success",
+		IsResidential: false,
+		IsBroadcast:   false,
+		FraudScore:    8,
+		QualityStatus: "success",
+	}
+
+	got := buildSurgeRenamedNodeLink(node, node.LinkName, "$Source$Flag$LinkCountry|$Residential|$IpType|$FraudScoreIcon$Speed-$Index", node.Link, 7)
+
+	if !strings.Contains(got, "%5BBK%5D%F0%9F%87%BA%F0%9F%87%B8US%7C%E6%9C%BA%E6%88%BFIP%7C%E5%8E%9F%E7%94%9FIP%7C%E2%9A%AA1.25MB/s-7") {
+		t.Fatalf("expected surge renamed link to include quality fields, got %q", got)
+	}
+}
+
 func TestBuildDialerProxyNameMapIgnoresAmbiguousAliases(t *testing.T) {
 	nodes := []models.Node{
 		{ID: 1, Name: "same-old-name", LinkName: "same-old-name"},


### PR DESCRIPTION
## 描述

修复 Surge 导出节点命名中质量字段占位符取值不一致的问题。

此前 Surge 导出路径单独构造 `utils.NodeInfo`，遗漏了部分质量检测字段，导致 `$Residential`、`$IpType`、`$FraudScoreIcon` 在已有检测数据时仍可能渲染为 `未检测`。本 PR 改为复用通用的 `models.BuildNodeRenameInfo(...)`，让 Surge 与 Clash/common 命名逻辑保持一致。

## 关联 Issue

N/A

## 更改类型

- [x] 🐛 修复 Bug (Bug)
- [ ] ✨ 新功能 (Feature)
- [ ] 📝 文档更新 (Docs)
- [ ] 🎨 样式或界面改进 (UI)
- [ ] ♻️ 代码重构 (Refactor)
- [ ] ⚡ 性能优化 (Perf)
- [ ] 🔧 配置更改 (Config)
- [x] 🧪 测试更新 (Test)

## 更改内容

- Surge 节点重命名路径改为复用 `models.BuildNodeRenameInfo(...)`
- 移除 Surge 专用的重复 `NodeInfo` 构造逻辑，避免字段映射继续漂移
- 新增回归测试，覆盖 `$Residential`、`$IpType`、`$FraudScoreIcon` 在 Surge 导出中的渲染结果

## 截图

<img width="415" height="606" alt="PixPin_2026-06-09_02-41-29" src="https://github.com/user-attachments/assets/f93ae36c-84a3-4abb-8b1f-9d1bb8a4cfe0" />

## 检查清单

- [x] 我的代码遵循项目代码风格

- [x] 后端检查已通过

  ```text
  golangci-lint run
  go test ./...