### PR TITLE
fix(subscription): 修复订阅导出代理名重复

### DIFF
--- a/api/clients.go
+++ b/api/clients.go
@@ -373,25 +373,70 @@ func applyPreparedResponseMode(prepared preparedClientResponse) resolvedPrepared
 	}
 }
 
-func buildRenamedNodeLink(node models.Node, processedLinkName, nodeNameRule, link string, index int) string {
+// buildNodeExportName 计算节点导出到客户端时使用的最终名称。
+// 原来在 buildRenamedNodeLink 内部直接计算并写回链接；现在先拆出名称计算，
+// 让导出阶段可以先做全局唯一化，再用同一个最终名称重写链接和代理组引用。
+// 这里只保留现有命名规则语义：无模板时使用节点有效名，有模板时按模板渲染。
+func buildNodeExportName(node models.Node, processedLinkName, nodeNameRule, link string, index int) string {
 	if nodeNameRule == "" {
-		return utils.RenameNodeLink(link, node.EffectiveName())
+		return node.EffectiveName()
 	}
-	newName := utils.RenameNode(nodeNameRule, models.BuildNodeRenameInfo(node, processedLinkName, protocol.GetProtocolFromLink(link), index))
+	return utils.RenameNode(nodeNameRule, models.BuildNodeRenameInfo(node, processedLinkName, protocol.GetProtocolFromLink(link), index))
+}
+
+func buildRenamedNodeLink(node models.Node, processedLinkName, nodeNameRule, link string, index int) string {
+	newName := buildNodeExportName(node, processedLinkName, nodeNameRule, link, index)
 	return utils.RenameNodeLink(link, newName)
 }
 
+// uniqueClientProxyName 为客户端导出的代理名称做最终去重。
+// Clash 和 Surge 都使用代理名称做组引用，重名会导致后续引用落到错误节点。
+func uniqueClientProxyName(baseName string, usedNames map[string]int) string {
+	baseName = strings.TrimSpace(baseName)
+	if baseName == "" {
+		baseName = "未命名节点"
+	}
+	if usedNames[baseName] == 0 {
+		usedNames[baseName] = 1
+		return baseName
+	}
+
+	for suffix := usedNames[baseName] + 1; ; suffix++ {
+		candidate := fmt.Sprintf("%s-%d", baseName, suffix)
+		if usedNames[candidate] == 0 {
+			usedNames[baseName] = suffix
+			usedNames[candidate] = 1
+			return candidate
+		}
+	}
+}
+
+// buildClashNodeNameMap 预先计算每个节点最终可引用的唯一代理名称。
+// 后续节点链接重命名、代理组和 dialer-proxy 都复用这张表，保证引用名称一致。
+// 这里替代原先各处临时计算名称的写法，避免同名节点在不同导出环节得到不一致的后缀。
 func buildClashNodeNameMap(sub models.Subcription) map[int]string {
 	nodeNameMap := make(map[int]string)
+	usedNames := make(map[string]int)
 	for idx, v := range sub.Nodes {
 		processedLinkName := utils.PreprocessNodeName(sub.NodeNamePreprocess, v.LinkName)
-		finalName := v.EffectiveName()
-		if sub.NodeNameRule != "" {
-			finalName = utils.RenameNode(sub.NodeNameRule, models.BuildNodeRenameInfo(v, processedLinkName, protocol.GetProtocolFromLink(v.Link), idx+1))
-		}
-		nodeNameMap[v.ID] = finalName
+		finalName := buildNodeExportName(v, processedLinkName, sub.NodeNameRule, v.Link, idx+1)
+		nodeNameMap[v.ID] = uniqueClientProxyName(finalName, usedNames)
 	}
 	return nodeNameMap
+}
+
+// buildUsedClientProxyNames 将已分配的客户端代理名称转为占用表。
+// 多 URL 节点拆分后还会追加多条代理，需要基于已有名称继续分配后缀。
+func buildUsedClientProxyNames(nodeNameMap map[int]string) map[string]int {
+	usedNames := make(map[string]int, len(nodeNameMap))
+	for _, name := range nodeNameMap {
+		trimmedName := strings.TrimSpace(name)
+		if trimmedName == "" {
+			continue
+		}
+		usedNames[trimmedName] = 1
+	}
+	return usedNames
 }
 
 func addDialerProxyNameAlias(aliasToFinal map[string]string, conflicts map[string]bool, alias, finalName string) {
@@ -687,16 +732,17 @@ func buildPreparedMihomoYAML(c *gin.Context, prepared preparedClientResponse) (m
 		utils.Debug("[ChainProxy] 收集完成: 目标节点=%d, 中间节点=%d", len(targetNodeDialerMap), len(chainNodeDialerMap))
 	}
 
-	// ========== 第二阶段：遍历节点生成配置 ==========
-	for idx, v := range sub.Nodes {
-		// 应用预处理规则到 LinkName
-		processedLinkName := utils.PreprocessNodeName(sub.NodeNamePreprocess, v.LinkName)
-		// 应用重命名规则
-		nodeLink := buildRenamedNodeLink(v, processedLinkName, sub.NodeNameRule, v.Link, idx+1)
+	// Clash 多 URL 节点会展开成多条 proxy，展开后的名称也必须参与全局去重。
+	clashURLNameCounters := make(map[int]int)
+	clashURLUsedNames := buildUsedClientProxyNames(nodeNameMap)
 
+	// ========== 第二阶段：遍历节点生成配置 ==========
+	for _, v := range sub.Nodes {
 		// 计算 dialer-proxy（链式代理规则）
 		// 优先级：中间节点映射 > 目标节点映射 > 节点自身设置
 		finalNodeName := nodeNameMap[v.ID]
+		// 使用已唯一化的名称重写链接，确保 proxy.name 与代理组、dialer-proxy 引用一致。
+		nodeLink := utils.RenameNodeLink(v.Link, finalNodeName)
 		dialerProxy := resolveClashDialerProxy(v, finalNodeName, chainNodeDialerMap, targetNodeDialerMap, dialerProxyNameMap)
 
 		switch {
@@ -704,7 +750,13 @@ func buildPreparedMihomoYAML(c *gin.Context, prepared preparedClientResponse) (m
 		case strings.Contains(v.Link, ","):
 			links := strings.Split(v.Link, ",")
 			for i, link := range links {
-				renamedLink := buildRenamedNodeLink(v, processedLinkName, sub.NodeNameRule, link, idx+1)
+				clashURLNameCounters[v.ID]++
+				linkName := finalNodeName
+				if clashURLNameCounters[v.ID] > 1 {
+					// 第一条使用节点主名称，后续拆分链接在完整名称末尾追加 -2、-3 等后缀。
+					linkName = uniqueClientProxyName(finalNodeName, clashURLUsedNames)
+				}
+				renamedLink := utils.RenameNodeLink(link, linkName)
 				links[i] = renamedLink
 				urls = append(urls, protocol.Urls{
 					Url:             renamedLink,
@@ -855,17 +907,28 @@ func renderPreparedSurge(c *gin.Context, prepared preparedClientResponse) {
 	}
 	sub := resolved.Subscription
 	urls := []string{}
-	for idx, v := range sub.Nodes {
-		// 应用预处理规则到 LinkName
-		processedLinkName := utils.PreprocessNodeName(sub.NodeNamePreprocess, v.LinkName)
-		// 应用重命名规则
-		nodeLink := buildRenamedNodeLink(v, processedLinkName, sub.NodeNameRule, v.Link, idx+1)
+
+	// Surge 的 [Proxy] 名称同样需要全局唯一，否则代理组引用会出现歧义。
+	nodeNameMap := buildClashNodeNameMap(sub)
+	surgeURLNameCounters := make(map[int]int)
+	surgeURLUsedNames := buildUsedClientProxyNames(nodeNameMap)
+
+	for _, v := range sub.Nodes {
+		finalNodeName := nodeNameMap[v.ID]
+		// Surge 的 [Proxy] 左侧名称来自链接名称，也要复用已唯一化结果。
+		nodeLink := utils.RenameNodeLink(v.Link, finalNodeName)
 		switch {
 		// 如果包含多条节点
 		case strings.Contains(v.Link, ","):
 			links := strings.Split(v.Link, ",")
 			for i, link := range links {
-				links[i] = buildRenamedNodeLink(v, processedLinkName, sub.NodeNameRule, link, idx+1)
+				surgeURLNameCounters[v.ID]++
+				linkName := finalNodeName
+				if surgeURLNameCounters[v.ID] > 1 {
+					// 第一条使用节点主名称，后续拆分链接在完整名称末尾追加 -2、-3 等后缀。
+					linkName = uniqueClientProxyName(finalNodeName, surgeURLUsedNames)
+				}
+				links[i] = utils.RenameNodeLink(link, linkName)
 			}
 			urls = append(urls, links...)
 			continue

--- a/api/clients_test.go
+++ b/api/clients_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/glebarez/sqlite"
+	"gopkg.in/yaml.v3"
 	"gorm.io/gorm"
 )
 
@@ -255,6 +256,114 @@ func performClientRequest(t *testing.T, method, path string) *httptest.ResponseR
 	return recorder
 }
 
+// clashProxyNamesFromBody 从 Clash YAML 输出中提取最终 proxy.name。
+// 这些名称是客户端真实引用的结果，比只测内部命名函数更接近导出行为。
+func clashProxyNamesFromBody(t *testing.T, body []byte) []string {
+	t.Helper()
+
+	var config struct {
+		Proxies []struct {
+			Name string `yaml:"name"`
+		} `yaml:"proxies"`
+	}
+	if err := yaml.Unmarshal(body, &config); err != nil {
+		t.Fatalf("parse clash output: %v\n%s", err, string(body))
+	}
+
+	names := make([]string, 0, len(config.Proxies))
+	for _, proxy := range config.Proxies {
+		names = append(names, proxy.Name)
+	}
+	return names
+}
+
+// surgeProxyNamesFromBody 从 Surge [Proxy] section 提取代理名称。
+// 只读取等号左侧名称，避免把 [Proxy Group] 中的组名误判为节点代理。
+func surgeProxyNamesFromBody(body string) []string {
+	lines := strings.Split(body, "\n")
+	inProxySection := false
+	names := []string{}
+
+	for _, line := range lines {
+		trimmedLine := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmedLine, "[") && strings.HasSuffix(trimmedLine, "]") {
+			inProxySection = trimmedLine == "[Proxy]"
+			continue
+		}
+		if !inProxySection || trimmedLine == "" || strings.HasPrefix(trimmedLine, "#") {
+			continue
+		}
+
+		parts := strings.SplitN(trimmedLine, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		names = append(names, strings.TrimSpace(parts[0]))
+	}
+
+	return names
+}
+
+func testClientProxyNameNodes(splitFirst bool) []models.Node {
+	firstLink := "ss://YWVzLTEyOC1nY206cGFzc0BleGFtcGxlLmNvbTo0NDM=#first"
+	if splitFirst {
+		firstLink = strings.Join([]string{
+			"ss://YWVzLTEyOC1nY206cGFzc0BleGFtcGxlLmNvbTo0NDM=#first-a",
+			"ss://YWVzLTEyOC1nY206cGFzc0BleGFtcGxlLm9yZzo0NDM=#first-b",
+		}, ",")
+	}
+
+	return []models.Node{
+		{ID: 1, Name: "first", LinkName: "first", Link: firstLink, Protocol: "ss", Source: "source-a"},
+		{
+			ID:       2,
+			Name:     "second",
+			LinkName: "second",
+			Link:     "ss://YWVzLTEyOC1nY206cGFzc0BleGFtcGxlLm5ldDo0NDM=#second",
+			Protocol: "ss",
+			Source:   "source-a",
+		},
+	}
+}
+
+func renderPreparedClientProxyNames(t *testing.T, clientType string, nodes []models.Node) []string {
+	t.Helper()
+	setupClientsAPITestDB(t)
+	utils.SetProtocolLinkFuncs(protocol.GetProtocolLabelFromLink, protocol.RenameNodeLink)
+	t.Cleanup(func() {
+		utils.SetProtocolLinkFuncs(nil, nil)
+	})
+
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	ginContext, _ := gin.CreateTestContext(recorder)
+	ginContext.Request = httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/c/?client="+clientType, nil)
+
+	templatePath := writeTestClashTemplate(t)
+	config := `{"clash":"` + templatePath + `"}`
+	prepared := preparedClientResponse{
+		ClientType: clientType,
+		Mode:       clientResponseNormal,
+		SubName:    "duplicate-name-sub",
+		Subscription: models.Subcription{
+			Name:                  "duplicate-name-sub",
+			Config:                config,
+			RefreshUsageOnRequest: false,
+			NodeNameRule:          "$Source",
+			Nodes:                 nodes,
+		},
+	}
+	if clientType == "surge" {
+		templatePath = writeTestSurgeTemplate(t)
+		prepared.Subscription.Config = `{"surge":"` + templatePath + `"}`
+		renderPreparedSurge(ginContext, prepared)
+		return surgeProxyNamesFromBody(recorder.Body.String())
+	}
+
+	renderPreparedClash(ginContext, prepared)
+	return clashProxyNamesFromBody(t, recorder.Body.Bytes())
+}
+
 func TestRenderPreparedV2raySkipsProtocolUnsupportedLinks(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	recorder := httptest.NewRecorder()
@@ -366,6 +475,53 @@ func TestResolveClashDialerProxyNormalizesStoredNameWithSubscriptionRule(t *test
 
 	if got != want {
 		t.Fatalf("expected stored dialer-proxy to normalize to subscription final name, got %q want %q", got, want)
+	}
+}
+
+// TestBuildClashNodeNameMapMakesDuplicateNamesUnique 覆盖客户端代理名称重名兜底。
+// 当多个节点按同一来源或模板渲染成同名时，后续节点应追加 -2、-3，避免客户端引用冲突。
+func TestBuildClashNodeNameMapMakesDuplicateNamesUnique(t *testing.T) {
+	sub := models.Subcription{
+		NodeNameRule: "$Source",
+		Nodes: []models.Node{
+			{ID: 1, Name: "first", LinkName: "first", Source: "source-a"},
+			{ID: 2, Name: "second", LinkName: "second", Source: "source-a"},
+			{ID: 3, Name: "third", LinkName: "third", Source: "source-a"},
+		},
+	}
+
+	nodeNameMap := buildClashNodeNameMap(sub)
+
+	if got := nodeNameMap[1]; got != "source-a" {
+		t.Fatalf("first name = %q, want source-a", got)
+	}
+	if got := nodeNameMap[2]; got != "source-a-2" {
+		t.Fatalf("second name = %q, want source-a-2", got)
+	}
+	if got := nodeNameMap[3]; got != "source-a-3" {
+		t.Fatalf("third name = %q, want source-a-3", got)
+	}
+}
+
+// TestBuildClashNodeNameMapKeepsDialerProxyAliasesAligned 确认去重后的名称仍能解析 dialer-proxy。
+// 链式代理或手工 dialer-proxy 可能保存旧名称，导出时必须映射到最终唯一 proxy.name。
+func TestBuildClashNodeNameMapKeepsDialerProxyAliasesAligned(t *testing.T) {
+	nodes := []models.Node{
+		{ID: 1, Name: "front-a", LinkName: "front-a", Source: "source-a"},
+		{ID: 2, Name: "front-b", LinkName: "front-b", Source: "source-a"},
+		{ID: 3, Name: "target", LinkName: "target", DialerProxyName: "front-b"},
+	}
+	sub := models.Subcription{
+		NodeNameRule: "$Source",
+		Nodes:        nodes,
+	}
+
+	nodeNameMap := buildClashNodeNameMap(sub)
+	dialerProxyNameMap := buildDialerProxyNameMap(nodes, nodeNameMap)
+	got := resolveClashDialerProxy(nodes[2], nodeNameMap[nodes[2].ID], nil, nil, dialerProxyNameMap)
+
+	if got != "source-a-2" {
+		t.Fatalf("expected dialer-proxy alias to resolve to unique final name, got %q", got)
 	}
 }
 
@@ -612,6 +768,31 @@ func TestRenderPreparedClashSetsProfileUpdateIntervalHeader(t *testing.T) {
 
 			if got := recorder.Header().Get("profile-update-interval"); got != tt.wantHeader {
 				t.Fatalf("expected profile-update-interval %q, got %q", tt.wantHeader, got)
+			}
+		})
+	}
+}
+
+// TestRenderPreparedClientMakesDuplicateProxyNamesUnique 从完整客户端输出验证代理名称唯一性。
+// Clash 和 Surge 都按名称引用代理，重复名称会让分组、规则或 dialer-proxy 出现歧义。
+func TestRenderPreparedClientMakesDuplicateProxyNamesUnique(t *testing.T) {
+	tests := []struct {
+		name       string
+		clientType string
+		splitFirst bool
+		wantNames  []string
+	}{
+		{name: "clash duplicate", clientType: "clash", wantNames: []string{"source-a", "source-a-2"}},
+		{name: "clash split", clientType: "clash", splitFirst: true, wantNames: []string{"source-a", "source-a-3", "source-a-2"}},
+		{name: "surge duplicate", clientType: "surge", wantNames: []string{"source-a", "source-a-2"}},
+		{name: "surge split", clientType: "surge", splitFirst: true, wantNames: []string{"source-a", "source-a-3", "source-a-2"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			names := renderPreparedClientProxyNames(t, tt.clientType, testClientProxyNameNodes(tt.splitFirst))
+			if strings.Join(names, ",") != strings.Join(tt.wantNames, ",") {
+				t.Fatalf("proxy names = %v, want %v", names, tt.wantNames)
 			}
 		})
 	}


### PR DESCRIPTION
## 描述

修复 Clash / Surge 导出中多个节点渲染后代理名称重复的问题。

节点命名模板常会把多个节点压缩成相同名称，例如只保留国家、地区、机场来源或某个分组字段。导出到客户端后，Clash 的 `proxy.name` 和 Surge 的 `[Proxy]` 名称都会被代理组、规则或链式代理引用；如果名称重复，客户端侧可能出现引用歧义、节点覆盖、分组指向错误节点等问题。

而节点命名规则中的`$Index - 序号`变量，是直接在所有节点后面编号`01`、`02`...，虽然解决了同名冲突问题，但看着不够优雅。

本 PR 在最终导出名称阶段做兜底去重：当多个节点渲染出相同代理名时，在完整最终名称末尾追加 `-2`、`-3` 等序号，如无同名节点，则保持模板设定的名字。尽量保留原命名模板的可读性，同时保证客户端配置中的代理名称唯一。

## 关联 Issue

Fixes #
Related to #

## 更改类型

- [x] 🐛 修复 Bug (Bug)
- [ ] ✨ 新功能 (Feature)
- [ ] 📝 文档更新 (Docs)
- [ ] 🎨 样式或界面改进 (UI)
- [ ] ♻️ 代码重构 (Refactor)
- [ ] ⚡ 性能优化 (Perf)
- [ ] 🔧 配置更改 (Config)
- [x] 🧪 测试更新 (Test)

## 更改内容

- 为 Clash / Surge 导出增加最终代理名称去重逻辑，重复名称会追加 `-2`、`-3` 等后缀
- 保证 Clash 代理组、链式代理和 `dialer-proxy` 引用使用去重后的最终名称
- 覆盖普通重复节点、多 URL 节点展开后的名称冲突，以及 Surge `[Proxy]` 输出去重测试

## 截图

<img width="969" height="318" alt="PixPin_2026-06-09_22-05-24" src="https://github.com/user-attachments/assets/3b0fbe05-9a57-4c0d-a2a3-0ab06f65ecab" />

## 检查清单

- [x] 我的代码遵循项目代码风格

- [x] 后端检查已通过

  ```text
  golangci-lint run
  go test ./...
  ```

- [ ] 前端改动已运行 `yarn run lint`

- [ ] UI 改动已检查 light/dark 和响应式状态

- [x] 已按需补充或更新后端测试、注释和文档

- [x] 行为或契约变化时，已检查跨层同步

- [x] 本次更改不会引入安全漏洞

已运行命令或检查：

```text
go test ./api -count=1
go test ./... -count=1
```

## 其他说明

已先拉取并 rebase 到上游最新 `origin/main`：

```text
e9b9672 feat(protocol): 增加 TUIC v5 的版本字段支持
```

本地验证 Surge 导出时，重复名称已从 `SG / SG / SG` 变为 `SG / SG-2 / SG-3`，Clash 与 Surge 都会在完整最终名称末尾追加序号。