### PR TITLE
feat(unlock): 新增巴哈姆特动画疯解锁检测

### DIFF
--- a/docs/features/unlock-check.md
+++ b/docs/features/unlock-check.md
@@ -24,6 +24,7 @@ First built in Providers:
 - OpenAI
 - Gemini
 - Claude
+- Bahamut Anime
 
 > [!NOTE]
 > Current built in Providers try to use service level probes consistent with mainstream unlock check scripts. For example, OpenAI checks Web and iOS entries separately, Disney+ uses device, token, and region GraphQL probes, while YouTube Premium, Gemini, Claude, and Netflix read availability markers from the relevant pages or final redirects.

--- a/docs/features/unlock-check.zh-CN.md
+++ b/docs/features/unlock-check.zh-CN.md
@@ -24,6 +24,7 @@ SublinkPro 现在支持在节点检测流程中附带执行 **流媒体 / AI 服
 - OpenAI
 - Gemini
 - Claude
+- 巴哈姆特动画疯
 
 > [!NOTE]
 > 当前内置 Provider 会尽量采用与主流解锁检测脚本一致的服务级探针：例如 OpenAI 会分别检查 Web / iOS 入口，Disney+ 会走设备、令牌与地区 GraphQL 探针，YouTube Premium、Gemini、Claude、Netflix 也会读取对应页面或最终跳转中的可用性标记。

--- a/models/unlock.go
+++ b/models/unlock.go
@@ -21,6 +21,7 @@ const (
 	UnlockProviderOpenAI    = "openai"
 	UnlockProviderGemini    = "gemini"
 	UnlockProviderClaude    = "claude"
+	UnlockProviderBahamut   = "bahamut"
 	UnlockStatusUntested    = "untested"
 	UnlockStatusAvailable   = "available"
 	UnlockStatusPartial     = "partial"
@@ -292,6 +293,8 @@ func defaultUnlockProviderMetaResolver(provider string) UnlockProviderMeta {
 		return UnlockProviderMeta{Value: UnlockProviderGemini, Label: "Gemini", Description: "检测 Google Gemini 服务地区可访问性", Category: "ai"}
 	case UnlockProviderClaude:
 		return UnlockProviderMeta{Value: UnlockProviderClaude, Label: "Claude", Description: "检测 Anthropic Claude 服务地区可访问性", Category: "ai"}
+	case UnlockProviderBahamut:
+		return UnlockProviderMeta{Value: UnlockProviderBahamut, Label: "Bahamut Anime", Description: "检测巴哈姆特动画疯（ani.gamer.com.tw）地区可访问性", Category: "streaming"}
 	default:
 		key := NormalizeUnlockProvider(provider)
 		return UnlockProviderMeta{Value: key, Label: provider, Category: "custom"}

--- a/services/unlock/checker_bahamut.go
+++ b/services/unlock/checker_bahamut.go
@@ -1,0 +1,269 @@
+package unlock
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/cookiejar"
+	"strings"
+	"time"
+
+	"sublink/models"
+)
+
+const (
+	bahamutProbeBodyLimit = 32 * 1024
+	bahamutTraceBodyLimit = 8 * 1024
+	bahamutDefaultTimeout = 20 * time.Second
+	bahamutRetryDeadline  = 30 * time.Second
+	// bahamutAdID 是巴哈姆特 token.php 接口固定的广告位参数
+	bahamutAdID = "89422"
+	// bahamutLenientSn 是入口探针动画 SN：港澳台 IP 均可获取 token，通过即表示在巴哈姆特服务区
+	bahamutLenientSn = "37783"
+	// bahamutStrictSn 是台湾确认探针动画 SN：仅台湾 IP 可获取 token，通过即表示出口在台湾
+	bahamutStrictSn = "38832"
+)
+
+type bahamutAnimeUnlockChecker struct{}
+
+func (bahamutAnimeUnlockChecker) Key() string { return models.UnlockProviderBahamut }
+
+func (bahamutAnimeUnlockChecker) Aliases() []string {
+	return []string{"bahamut", "bahamutanime", "ani_gamer", "animedance"}
+}
+
+func (bahamutAnimeUnlockChecker) Meta() models.UnlockProviderMeta {
+	return models.UnlockProviderMeta{
+		Value:       models.UnlockProviderBahamut,
+		Label:       "Bahamut Anime",
+		Description: "检测巴哈姆特动画疯（ani.gamer.com.tw）地区可访问性",
+		Category:    "streaming",
+	}
+}
+
+func (bahamutAnimeUnlockChecker) RenameVariableMeta() models.UnlockRenameVariableMeta {
+	return models.UnlockRenameVariableMeta{Provider: models.UnlockProviderBahamut}
+}
+
+// Check 执行巴哈姆特动画疯解锁检测。
+// 巴哈姆特需要 cookie jar 维持 deviceid→token 的 session 关联，
+// 因此 checker 自建 client（复用 runtime 的代理 Transport，但独立 session 策略）。
+func (bahamutAnimeUnlockChecker) Check(runtime UnlockRuntime) models.UnlockProviderResult {
+	client := bahamutClient(runtime)
+	headers := bahamutHeaders()
+
+	deviceIDBody, err := bahamutFetchBody(client, "https://ani.gamer.com.tw/ajax/getdeviceid.php", headers, bahamutProbeBodyLimit)
+	if err != nil {
+		return bahamutErrorResult(runtime, err.Error())
+	}
+	deviceIDResp := &unlockHTTPResponse{RawBody: string(deviceIDBody)}
+	deviceID, unsupported := evaluateBahamutDeviceID(deviceIDResp.RawBody)
+	// HTML 拦截页短路：地区完全不在服务范围，跳过后续 token 探针
+	if unsupported {
+		return evaluateBahamutUnlockProbe(runtime, deviceIDResp, nil, nil, nil)
+	}
+
+	// 入口探针先查：通过是 Available 的前提，不通过直接短路
+	lenientBody, err := bahamutFetchBody(client, bahamutTokenURL(bahamutLenientSn, deviceID), headers, bahamutProbeBodyLimit)
+	if err != nil {
+		return bahamutErrorResult(runtime, err.Error())
+	}
+	lenientResp := &unlockHTTPResponse{RawBody: string(lenientBody)}
+	if !evaluateBahamutToken(lenientResp.RawBody) {
+		return evaluateBahamutUnlockProbe(runtime, deviceIDResp, lenientResp, nil, nil)
+	}
+
+	// 台湾确认探针：通过则直接返回 TW，无需 trace
+	strictBody, err := bahamutFetchBody(client, bahamutTokenURL(bahamutStrictSn, deviceID), headers, bahamutProbeBodyLimit)
+	if err != nil {
+		return bahamutErrorResult(runtime, err.Error())
+	}
+	strictResp := &unlockHTTPResponse{RawBody: string(strictBody)}
+	if evaluateBahamutToken(strictResp.RawBody) {
+		return evaluateBahamutUnlockProbe(runtime, deviceIDResp, lenientResp, strictResp, nil)
+	}
+
+	// 入口通过但台湾探针未通过：查 trace 拿港澳台具体 region
+	traceBody, _ := bahamutFetchBody(client, "https://ani.gamer.com.tw/cdn-cgi/trace", headers, bahamutTraceBodyLimit)
+	var traceResp *unlockHTTPResponse
+	if len(traceBody) > 0 {
+		traceResp = &unlockHTTPResponse{RawBody: string(traceBody)}
+	}
+	return evaluateBahamutUnlockProbe(runtime, deviceIDResp, lenientResp, strictResp, traceResp)
+}
+
+// evaluateBahamutUnlockProbe 根据各探针响应判定巴哈姆特解锁状态（纯函数，便于测试）。
+// 判定顺序：deviceID 受限 → 入口探针不通过 → 台湾探针通过 → 港澳台 trace。
+func evaluateBahamutUnlockProbe(runtime UnlockRuntime, deviceIDResp, lenientResp, strictResp, traceResp *unlockHTTPResponse) models.UnlockProviderResult {
+	if deviceIDResp == nil || deviceIDResp.RawBody == "" {
+		return bahamutErrorResult(runtime, "network_connection")
+	}
+
+	_, unsupported := evaluateBahamutDeviceID(deviceIDResp.RawBody)
+	if unsupported {
+		return models.UnlockProviderResult{Provider: models.UnlockProviderBahamut, Status: models.UnlockStatusUnsupported, Region: runtime.LandingCountry, Reason: "not_available"}
+	}
+
+	// 入口探针不通过：完全不在巴哈姆特服务区
+	if lenientResp == nil || !evaluateBahamutToken(lenientResp.RawBody) {
+		return models.UnlockProviderResult{Provider: models.UnlockProviderBahamut, Status: models.UnlockStatusUnsupported, Region: runtime.LandingCountry, Reason: "region_unavailable"}
+	}
+
+	// 台湾确认探针通过：完整台湾解锁
+	if strictResp != nil && evaluateBahamutToken(strictResp.RawBody) {
+		return models.UnlockProviderResult{Provider: models.UnlockProviderBahamut, Status: models.UnlockStatusAvailable, Region: "TW"}
+	}
+
+	// 入口通过但台湾探针未通过：港澳台可用，从 trace 拿 region
+	region := ""
+	if traceResp != nil {
+		region = evaluateBahamutRegion(traceResp.RawBody)
+	}
+	if region == "" {
+		// trace 失败时按原始实现降级为 partial，避免误报精确地区
+		return models.UnlockProviderResult{Provider: models.UnlockProviderBahamut, Status: models.UnlockStatusPartial, Region: runtime.LandingCountry, Detail: "primary_token_only"}
+	}
+	return models.UnlockProviderResult{Provider: models.UnlockProviderBahamut, Status: models.UnlockStatusAvailable, Region: region}
+}
+
+// evaluateBahamutDeviceID 解析 getdeviceid.php 响应，返回 deviceID 和是否为不支持地区。
+// 非 JSON 且以 < 开头的响应视为地区受限的 HTML 拦截页。
+func evaluateBahamutDeviceID(rawBody string) (deviceID string, unsupported bool) {
+	var result struct {
+		Deviceid string `json:"deviceid"`
+	}
+	if err := json.Unmarshal([]byte(rawBody), &result); err != nil {
+		if strings.HasPrefix(strings.TrimSpace(rawBody), "<") {
+			return "", true
+		}
+		return "", false
+	}
+	return result.Deviceid, false
+}
+
+// evaluateBahamutToken 解析 token.php 响应，判断该 SN 是否可获取 token。
+// animeSn 非零表示当前 IP 在该 SN 对应的可观看地区内。
+func evaluateBahamutToken(rawBody string) bool {
+	var result struct {
+		AnimeSn int `json:"animeSn"`
+	}
+	if err := json.Unmarshal([]byte(rawBody), &result); err != nil {
+		return false
+	}
+	return result.AnimeSn != 0
+}
+
+// evaluateBahamutRegion 从 cdn-cgi/trace 响应中提取两字母地区代码（大写）。
+func evaluateBahamutRegion(rawBody string) string {
+	idx := strings.Index(rawBody, "loc=")
+	if idx == -1 {
+		return ""
+	}
+	rest := rawBody[idx+4:]
+	idx = strings.Index(rest, "\n")
+	if idx == -1 {
+		return ""
+	}
+	loc := strings.TrimSpace(rest[:idx])
+	if len(loc) == 2 {
+		return strings.ToUpper(loc)
+	}
+	return ""
+}
+
+// bahamutClient 构造巴哈姆特专属 HTTP client。
+// Transport 复用 runtime 的代理拨号路径（必须共享，走节点代理），
+// 但 cookie jar 和 redirect 策略独立——deviceid→token 的 session 关联需要 cookie 维持。
+func bahamutClient(runtime UnlockRuntime) *http.Client {
+	jar, _ := cookiejar.New(nil)
+	timeout := runtime.Timeout
+	if timeout <= 0 || timeout < bahamutDefaultTimeout {
+		timeout = bahamutDefaultTimeout
+	}
+	return &http.Client{
+		Transport:     runtime.Client.Transport,
+		Timeout:       timeout,
+		CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
+		Jar:           jar,
+	}
+}
+
+// bahamutFetchBody 执行 GET 请求并返回受限的 body。
+// 重试 3 次（参考项目语义），遇到 no such host / timeout 立即停止。
+func bahamutFetchBody(client *http.Client, target string, headers map[string]string, bodyLimit int64) ([]byte, error) {
+	if bodyLimit <= 0 {
+		bodyLimit = bahamutProbeBodyLimit
+	}
+	timeout := client.Timeout
+	if timeout <= 0 {
+		timeout = bahamutDefaultTimeout
+	}
+
+	var lastErr error
+	deadline := time.Now().Add(bahamutRetryDeadline)
+	for i := 0; i < 3; i++ {
+		if time.Now().After(deadline) {
+			break
+		}
+		body, err := bahamutFetchBodyOnce(client, target, headers, bodyLimit, timeout)
+		if err == nil {
+			return body, nil
+		}
+		lastErr = err
+		if bahamutShouldStopRetry(err) {
+			break
+		}
+	}
+	return nil, lastErr
+}
+
+func bahamutFetchBodyOnce(client *http.Client, target string, headers map[string]string, bodyLimit int64, timeout time.Duration) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, target, nil)
+	if err != nil {
+		return nil, err
+	}
+	for key, value := range headers {
+		if strings.TrimSpace(key) != "" && strings.TrimSpace(value) != "" {
+			req.Header.Set(key, value)
+		}
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	return io.ReadAll(io.LimitReader(resp.Body, bodyLimit))
+}
+
+func bahamutShouldStopRetry(err error) bool {
+	if err == nil {
+		return false
+	}
+	errText := strings.ToLower(err.Error())
+	return strings.Contains(errText, "no such host") || strings.Contains(errText, "timeout")
+}
+
+func bahamutTokenURL(sn, deviceID string) string {
+	return fmt.Sprintf("https://ani.gamer.com.tw/ajax/token.php?adID=%s&sn=%s&device=%s", bahamutAdID, sn, deviceID)
+}
+
+func bahamutHeaders() map[string]string {
+	return map[string]string{
+		"Accept":          "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
+		"Accept-Language": "zh-CN,zh;q=0.9,en;q=0.8",
+		"User-Agent":      "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36 Edg/124.0.0.0",
+	}
+}
+
+func bahamutErrorResult(runtime UnlockRuntime, reason string) models.UnlockProviderResult {
+	return models.UnlockProviderResult{Provider: models.UnlockProviderBahamut, Status: models.UnlockStatusError, Region: runtime.LandingCountry, Reason: reason}
+}
+
+func init() {
+	RegisterUnlockChecker(bahamutAnimeUnlockChecker{})
+}

--- a/services/unlock/checker_bahamut_test.go
+++ b/services/unlock/checker_bahamut_test.go
@@ -1,0 +1,193 @@
+package unlock
+
+import (
+	"net/http"
+	"testing"
+
+	"sublink/models"
+)
+
+func TestEvaluateBahamutDeviceID(t *testing.T) {
+	tests := []struct {
+		name            string
+		body            string
+		wantDeviceID    string
+		wantUnsupported bool
+	}{
+		{name: "valid device ID", body: `{"deviceid":"abc123","animeSn":0}`, wantDeviceID: "abc123"},
+		{name: "empty device ID", body: `{"deviceid":"","animeSn":0}`, wantDeviceID: ""},
+		{name: "HTML response - unsupported", body: `<html><body>not available</body></html>`, wantUnsupported: true},
+		{name: "garbage JSON - not unsupported", body: `not json at all`, wantDeviceID: "", wantUnsupported: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			deviceID, unsupported := evaluateBahamutDeviceID(tt.body)
+			if deviceID != tt.wantDeviceID {
+				t.Fatalf("deviceID = %q, want %q", deviceID, tt.wantDeviceID)
+			}
+			if unsupported != tt.wantUnsupported {
+				t.Fatalf("unsupported = %v, want %v", unsupported, tt.wantUnsupported)
+			}
+		})
+	}
+}
+
+func TestEvaluateBahamutToken(t *testing.T) {
+	tests := []struct {
+		name      string
+		body      string
+		wantAvail bool
+	}{
+		{name: "token available", body: `{"animeSn":37783}`, wantAvail: true},
+		{name: "token unavailable", body: `{"animeSn":0}`, wantAvail: false},
+		{name: "garbage JSON", body: `not json`, wantAvail: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := evaluateBahamutToken(tt.body); got != tt.wantAvail {
+				t.Fatalf("evaluateBahamutToken() = %v, want %v", got, tt.wantAvail)
+			}
+		})
+	}
+}
+
+func TestEvaluateBahamutRegion(t *testing.T) {
+	tests := []struct {
+		name       string
+		body       string
+		wantRegion string
+	}{
+		{name: "TW region", body: "ip=1.2.3.4\nloc=TW\nvisit_scheme=https\n", wantRegion: "TW"},
+		{name: "HK region", body: "ip=1.2.3.4\nloc=HK\nvisit_scheme=https\n", wantRegion: "HK"},
+		{name: "lowercase normalized to upper", body: "ip=1.2.3.4\nloc=tw\n", wantRegion: "TW"},
+		{name: "no loc field", body: "ip=1.2.3.4\nvisit_scheme=https\n", wantRegion: ""},
+		{name: "empty body", body: "", wantRegion: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := evaluateBahamutRegion(tt.body); got != tt.wantRegion {
+				t.Fatalf("region = %q, want %q", got, tt.wantRegion)
+			}
+		})
+	}
+}
+
+// TestEvaluateBahamutUnlockProbe 覆盖 Check 的所有判定分支。
+// 参数顺序：deviceIDResp, lenientResp(37783), strictResp(38832), traceResp。
+// 判定语义参考 MediaUnlockTest/checks/BahamutAnime.go：
+//   - 入口探针(37783)通过是 Available 的前提
+//   - 台湾探针(38832)通过 → Available TW
+//   - 38832 不通过 + trace loc → Available loc（港澳台）
+//   - 37783 不通过 → Unsupported
+func TestEvaluateBahamutUnlockProbe(t *testing.T) {
+	runtime := UnlockRuntime{LandingCountry: "US"}
+	deviceIDOK := unlockTestResponse(http.StatusOK, "", `{"deviceid":"dev123","animeSn":0}`)
+	lenientOK := unlockTestResponse(http.StatusOK, "", `{"animeSn":37783}`)
+	strictOK := unlockTestResponse(http.StatusOK, "", `{"animeSn":38832}`)
+	strictFail := unlockTestResponse(http.StatusOK, "", `{"animeSn":0}`)
+
+	tests := []struct {
+		name       string
+		deviceID   *unlockHTTPResponse
+		lenient    *unlockHTTPResponse
+		strict     *unlockHTTPResponse
+		trace      *unlockHTTPResponse
+		wantStatus string
+		wantRegion string
+		wantReason string
+		wantDetail string
+	}{
+		{
+			name:       "HTML device ID - unsupported",
+			deviceID:   unlockTestResponse(http.StatusOK, "", `<html>blocked</html>`),
+			wantStatus: models.UnlockStatusUnsupported,
+			wantRegion: "US",
+			wantReason: "not_available",
+		},
+		{
+			name:       "lenient fails - unsupported",
+			deviceID:   deviceIDOK,
+			lenient:    unlockTestResponse(http.StatusOK, "", `{"animeSn":0}`),
+			wantStatus: models.UnlockStatusUnsupported,
+			wantRegion: "US",
+			wantReason: "region_unavailable",
+		},
+		{
+			name:       "lenient + strict pass - TW full unlock",
+			deviceID:   deviceIDOK,
+			lenient:    lenientOK,
+			strict:     strictOK,
+			wantStatus: models.UnlockStatusAvailable,
+			wantRegion: "TW",
+		},
+		{
+			name:       "lenient pass + strict fail + HK trace - HK available",
+			deviceID:   deviceIDOK,
+			lenient:    lenientOK,
+			strict:     strictFail,
+			trace:      unlockTestResponse(http.StatusOK, "", "ip=1.2.3.4\nloc=HK\n"),
+			wantStatus: models.UnlockStatusAvailable,
+			wantRegion: "HK",
+		},
+		{
+			name:       "lenient pass + strict fail + MO trace - MO available",
+			deviceID:   deviceIDOK,
+			lenient:    lenientOK,
+			strict:     strictFail,
+			trace:      unlockTestResponse(http.StatusOK, "", "ip=1.2.3.4\nloc=MO\n"),
+			wantStatus: models.UnlockStatusAvailable,
+			wantRegion: "MO",
+		},
+		{
+			name:       "lenient pass + strict fail + no trace - partial fallback",
+			deviceID:   deviceIDOK,
+			lenient:    lenientOK,
+			strict:     strictFail,
+			trace:      nil,
+			wantStatus: models.UnlockStatusPartial,
+			wantRegion: "US",
+			wantDetail: "primary_token_only",
+		},
+		{
+			name:       "empty device ID response - error",
+			deviceID:   unlockTestResponse(http.StatusOK, "", ""),
+			wantStatus: models.UnlockStatusError,
+			wantRegion: "US",
+			wantReason: "network_connection",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := evaluateBahamutUnlockProbe(runtime, tt.deviceID, tt.lenient, tt.strict, tt.trace)
+			assertUnlockResult(t, result, models.UnlockProviderBahamut, tt.wantStatus, tt.wantRegion, tt.wantReason, tt.wantDetail)
+		})
+	}
+}
+
+func TestBahamutMeta(t *testing.T) {
+	checker := bahamutAnimeUnlockChecker{}
+
+	if checker.Key() != models.UnlockProviderBahamut {
+		t.Fatalf("Key() = %q, want %q", checker.Key(), models.UnlockProviderBahamut)
+	}
+
+	meta := checker.Meta()
+	if meta.Value != models.UnlockProviderBahamut {
+		t.Fatalf("Meta().Value = %q, want %q", meta.Value, models.UnlockProviderBahamut)
+	}
+	if meta.Label == "" {
+		t.Fatal("Meta().Label is empty")
+	}
+	if meta.Category != "streaming" {
+		t.Fatalf("Meta().Category = %q, want %q", meta.Category, "streaming")
+	}
+
+	renameMeta := checker.RenameVariableMeta()
+	if renameMeta.Provider != models.UnlockProviderBahamut {
+		t.Fatalf("RenameVariableMeta().Provider = %q, want %q", renameMeta.Provider, models.UnlockProviderBahamut)
+	}
+}


### PR DESCRIPTION
## Summary

新增 Bahamut Anime（巴哈姆特动画疯，`ani.gamer.com.tw`）解锁检测 checker。

检测逻辑对齐 [MediaUnlockTest/checks/BahamutAnime.go](https://github.com/nkeonkeo/MediaUnlockTest/blob/main/checks/BahamutAnime.go) 的语义：

1. `getdeviceid.php` 获取 deviceID（cookie jar 维持 session）
2. **入口探针** `sn=37783`（港澳台 IP 均可获取 token）—— 通过是 Available 的前提
3. **台湾确认探针** `sn=38832`（仅台湾 IP 可获取 token）—— 通过直接返回 `Available TW`
4. 入口通过但台湾未通过 + `cdn-cgi/trace`：返回 `Available + 港澳台地区`
5. 入口未通过：`Unsupported`
6. deviceID 返回 HTML 拦截页：`Unsupported`（地区完全不在服务范围）

## Changes

- `services/unlock/checker_bahamut.go`：新增 checker 实现
- `services/unlock/checker_bahamut_test.go`：纯函数测试，覆盖 7 条判定分支
- `models/unlock.go`：注册 `UnlockProviderBahamut` 常量 + default resolver case
- `docs/features/unlock-check.md` / `unlock-check.zh-CN.md`：内置检查项列表同步（中英文成对）
- 前端无需改动（`webs/src/views/nodes/utils.js:73` 早有 `bahamut` 占位，Provider 选择器走后端元数据）

## 设计说明

### 1. 为什么 checker 自建 HTTP client 而不用 runtime 共享 client？

- **Transport必须共享 runtime.Client.Transport** —— 必须走节点代理，与其他 checker 一致
- **Client 层（session / redirect 策略）必须独立** —— 巴哈姆特 `getdeviceid.php → token.php` 流程依赖 cookie 维持 session 关联；同时需要 `CheckRedirect: ErrUseLastResponse` 避免被重定向到拦截页

### 2. 为什么 timeout 覆盖到 20s？

巴哈姆特 `token.php` 接口响应较慢，runtime 默认 5s 不够稳定。本实现取 20s 默认 + 30s 总重试 deadline 作为折中。checker 并发受 orchestrator 的 workerLimit=3 限制，不会拖慢整批检测。

### 3. 检测逻辑来源依据

判定顺序、SN 编号、cookie session 要求全部对齐上游主流检测项目 [MediaUnlockTest](https://github.com/nkeonkeo/MediaUnlockTest)，已用真实台湾/香港/美国节点验证结果正确。

## Validation

- [x] `gofmt -l` 通过
- [x] `go build ./services/unlock/... ./models/...` 通过
- [x] `go test ./services/unlock/...` 全部 PASS（含原有 6 个 checker 测试无回归）
- [x] 真实节点验证：台湾 → `支持·TW`，港澳台 → `支持·HK/MO`，其他 → `不支持`
- [x] 中英文文档同步