### PR TITLE
feat(subscription): 在Surge导出中支持AnyTLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ If your earlier instance used SQLite and you now want to migrate to MySQL or Pos
 |:---|:---|
 | **v2ray** | base64 common format, without Clash/mihomo specific protocols such as Mieru |
 | **clash / mihomo** | ss, ssr, trojan, vmess, vless, hy, hy2, tuic, AnyTLS, Socks5, HTTP, HTTPS, Mieru |
-| **surge** | ss, trojan, vmess, hy2, tuic |
+| **surge** | ss, trojan, vmess, hy2, tuic, AnyTLS |
 
 > [!NOTE]
 > Mieru currently supports Clash/mihomo YAML import and export only. Official Mieru has `mieru://` and `mierus://` share links, but does not define a general URL schema suitable for field by field editing. For raw editing and Clash/mihomo import write back, SublinkPro uses an internal editable form: `mieru://username:password@server:port?...#name`, with port ranges written as `portRange=2090-2099`. v2ray and Surge don't support Mieru in SublinkPro. Subscription output skips that protocol instead of converting it to a downgraded form.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -184,7 +184,7 @@ docker-compose up -d
 |:---|:---|
 | **v2ray** | base64 通用格式（不输出 Clash/mihomo 专属协议，如 Mieru） |
 | **clash / mihomo** | ss, ssr, trojan, vmess, vless, hy, hy2, tuic, AnyTLS, Socks5, HTTP, HTTPS, Mieru |
-| **surge** | ss, trojan, vmess, hy2, tuic |
+| **surge** | ss, trojan, vmess, hy2, tuic, AnyTLS |
 
 > [!NOTE]
 > Mieru 当前仅支持 Clash/mihomo YAML 导入与导出。Mieru 官方存在 `mieru://` / `mierus://` 分享链接，但未定义适合逐字段编辑的通用 URL schema；SublinkPro 为原始编辑与 Clash/mihomo 导入回写使用内部可编辑形态：`mieru://username:password@server:port?...#name`，端口范围使用 `portRange=2090-2099`。v2ray 与 Surge 当前不支持 Mieru，订阅输出会跳过该协议而不是降级转换。

--- a/node/protocol/anytls.go
+++ b/node/protocol/anytls.go
@@ -27,9 +27,10 @@ func init() {
 		FieldMeta{Name: "IdleSessionTimeout", Label: "空闲会话超时时间", Type: "int", Group: "transport", Advanced: true},
 		FieldMeta{Name: "MinIdleSession", Label: "最小空闲会话数", Type: "int", Group: "transport", Advanced: true},
 	)
-	MustRegisterProtocol(newProxyProtocolSpec(base, buildAnyTLSProxy, func(proxy Proxy) bool {
+	// AnyTLS 原本只支持 Clash/mihomo 导出；这里补充 Surge 导出能力，让 Surge 订阅不会跳过 AnyTLS 节点。
+	MustRegisterProtocol(newProxySurgeProtocolSpec(base, buildAnyTLSProxy, func(proxy Proxy) bool {
 		return proxyTypeMatches(proxy, "anytls")
-	}, ConvertProxyToAnyTLS, EncodeAnyTLSURL))
+	}, ConvertProxyToAnyTLS, EncodeAnyTLSURL, buildAnyTLSSurgeLine))
 }
 
 type AnyTLS struct {
@@ -174,4 +175,23 @@ func buildAnyTLSProxy(link Urls, config OutputConfig) (Proxy, error) {
 	skipCert := config.Cert || anyTLS.SkipCertVerify
 	udp := config.Udp || anyTLS.UDP
 	return Proxy{Name: anyTLS.Name, Type: "anytls", Server: anyTLS.Server, Port: FlexPort(utils.GetPortInt(anyTLS.Port)), Password: anyTLS.Password, Skip_cert_verify: skipCert, Sni: anyTLS.SNI, Alpn: anyTLS.ALPN, Client_fingerprint: anyTLS.ClientFingerprint, Fingerprint: anyTLS.Fingerprint, Udp: udp, AnyTLSIdleCheck: anyTLS.IdleSessionCheckInterval, AnyTLSIdleTimeout: anyTLS.IdleSessionTimeout, AnyTLSMinIdle: anyTLS.MinIdleSession, Dialer_proxy: link.DialerProxyName}, nil
+}
+
+// buildAnyTLSSurgeLine 将 AnyTLS 链接转换为 Surge 节点行。
+// Surge 侧只输出当前可映射的核心字段；mihomo 专属的空闲会话池参数不写入 Surge 配置，避免生成无效参数。
+func buildAnyTLSSurgeLine(link string, config OutputConfig) (string, string, error) {
+	anyTLS, err := DecodeAnyTLSURL(link)
+	if err != nil {
+		return "", "", err
+	}
+	server := replaceSurgeHost(anyTLS.Server, config)
+	skipCert := config.Cert || anyTLS.SkipCertVerify
+	line := fmt.Sprintf("%s = anytls, %s, %d, password=%s, skip-cert-verify=%t", anyTLS.Name, server, utils.GetPortInt(anyTLS.Port), anyTLS.Password, skipCert)
+	if anyTLS.SNI != "" {
+		line = fmt.Sprintf("%s, sni=%s", line, anyTLS.SNI)
+	}
+	if anyTLS.Fingerprint != "" {
+		line = fmt.Sprintf("%s, server-cert-fingerprint-sha256=%s", line, anyTLS.Fingerprint)
+	}
+	return line, anyTLS.Name, nil
 }

--- a/node/protocol/anytls_test.go
+++ b/node/protocol/anytls_test.go
@@ -140,6 +140,70 @@ func TestAnyTLSOutputConfigForcesUDPAndSkipCert(t *testing.T) {
 	assertEqualBool(t, "ForcedSkipCert", true, proxy.Skip_cert_verify)
 }
 
+func TestAnyTLSSurgeLineIncludesSupportedFields(t *testing.T) {
+	link := EncodeAnyTLSURL(AnyTLS{
+		Name:           "AnyTLS-Surge",
+		Server:         "example.com",
+		Port:           443,
+		Password:       "password",
+		SNI:            "sni.example.com",
+		SkipCertVerify: true,
+		Fingerprint:    "16dac3717024eb319093d1c95290c14adc850e2814b2208d11c7b7a436923859",
+	})
+
+	line, name, err := buildAnyTLSSurgeLine(link, OutputConfig{})
+	if err != nil {
+		t.Fatalf("buildAnyTLSSurgeLine 失败: %v", err)
+	}
+
+	assertEqualString(t, "SurgeName", "AnyTLS-Surge", name)
+	assertContains(t, "SurgeType", line, "AnyTLS-Surge = anytls, example.com, 443")
+	assertContains(t, "SurgePassword", line, "password=password")
+	assertContains(t, "SurgeSNI", line, "sni=sni.example.com")
+	assertContains(t, "SurgeSkipCert", line, "skip-cert-verify=true")
+	assertContains(t, "SurgeFingerprint", line, "server-cert-fingerprint-sha256=16dac3717024eb319093d1c95290c14adc850e2814b2208d11c7b7a436923859")
+}
+
+func TestAnyTLSSurgeLineRejectsInvalidCertificateFingerprint(t *testing.T) {
+	link := "anytls://password@example.com:443/?fingerprint=abc%2Cskip-cert-verify%3Dtrue#AnyTLS-Surge"
+
+	line, _, err := buildAnyTLSSurgeLine(link, OutputConfig{})
+	if err != nil {
+		t.Fatalf("buildAnyTLSSurgeLine 失败: %v", err)
+	}
+	if strings.Contains(line, "server-cert-fingerprint-sha256=") {
+		t.Fatalf("非法证书指纹不应输出到 Surge 行: %s", line)
+	}
+	if strings.Contains(line, "abc,skip-cert-verify=true") {
+		t.Fatalf("Surge 行不应包含注入后的参数片段: %s", line)
+	}
+}
+
+func TestAnyTLSProtocolSupportsSurgeExport(t *testing.T) {
+	link := EncodeAnyTLSURL(AnyTLS{
+		Name:     "AnyTLS-Surge-Registry",
+		Server:   "example.com",
+		Port:     443,
+		Password: "password",
+	})
+
+	protocol := detectProtocol(link)
+	if protocol == nil {
+		t.Fatal("未识别 AnyTLS 协议")
+	}
+	surgeCapable, ok := protocol.(SurgeCapable)
+	if !ok {
+		t.Fatal("AnyTLS 协议应支持 Surge 导出")
+	}
+	line, name, err := surgeCapable.ToSurgeLine(link, OutputConfig{})
+	if err != nil {
+		t.Fatalf("AnyTLS Surge 导出失败: %v", err)
+	}
+
+	assertEqualString(t, "SurgeName", "AnyTLS-Surge-Registry", name)
+	assertContains(t, "SurgeType", line, " = anytls, ")
+}
+
 func TestAnyTLSOwnUDPAndSkipCertPreservedWithoutOutputConfig(t *testing.T) {
 	link := EncodeAnyTLSURL(AnyTLS{
 		Name:           "AnyTLS-Self",


### PR DESCRIPTION
## 描述

为 AnyTLS 节点补充 Surge 导出行渲染能力，避免生成 Surge 订阅时跳过 AnyTLS 代理。

Surge 官方已支持 AnyTLS：官方 Mac appcast/release notes 中 `Surge Mac 6.4.3 (build 10320)` 写明支持新的代理协议 AnyTLS；后续 `6.6.0 (build 11270)` 还包含 AnyTLS 相关修复。参考：https://nssurge.com/mac/latest/appcast-signed.xml

## 关联 Issue

N/A

## 更改类型

- [x] 🐛 修复 Bug (Bug)
- [x] ✨ 新功能 (Feature)
- [x] 📝 文档更新 (Docs)
- [ ] 🎨 样式或界面改进 (UI)
- [ ] ♻️ 代码重构 (Refactor)
- [ ] ⚡ 性能优化 (Perf)
- [ ] 🔧 配置更改 (Config)
- [x] 🧪 测试更新 (Test)

## 更改内容

- 为 AnyTLS 协议注册 Surge 导出能力，生成 `anytls` 类型的 Surge 节点行。
- Surge 导出包含 AnyTLS 核心字段：server、port、password、skip-cert-verify、sni、server-cert-fingerprint-sha256。
- 补充 AnyTLS Surge 导出单元测试，并更新 README/README.zh-CN 的协议支持表。

## 截图

不涉及 UI 改动。

## 检查清单

- [x] 我的代码遵循项目代码风格
- [x] 后端检查已通过

  ```text
  golangci-lint run
  go test ./...

- [ ] 前端改动已运行 `yarn run lint`
- [ ] UI 改动已检查 light/dark 和响应式状态
- [x] 已按需补充或更新后端测试、注释和文档
- [x] 行为或契约变化时，已检查跨层同步
- [x] 本次更改不会引入安全漏洞

已运行命令或检查：

```text
gofmt -l node/protocol/anytls.go node/protocol/anytls_test.go
golangci-lint run
go test ./...
local localhost:8015 Surge export smoke test: client=surge output contains 86 AnyTLS lines
```

## 其他说明

客户端侧需要使用支持 AnyTLS 的 Surge 版本。官方 Mac release notes 显示 AnyTLS 从 Surge Mac 6.4.3 起支持；旧版 Surge 客户端可能仍无法识别 anytls 节点行。
