### PR TITLE
perf(unlock): 收紧巴哈姆特解锁检测的超时与重试上界

### DIFF
--- a/services/unlock/checker_bahamut.go
+++ b/services/unlock/checker_bahamut.go
@@ -16,8 +16,13 @@ import (
 const (
 	bahamutProbeBodyLimit = 32 * 1024
 	bahamutTraceBodyLimit = 8 * 1024
-	bahamutDefaultTimeout = 15 * time.Second
-	bahamutRetryDeadline  = 50 * time.Second
+	// bahamutDefaultTimeout 与 runtime.go 全局默认对齐：解锁检测对慢节点不需要宽裕兜底，
+	// 慢节点即使解锁成功用户也不会选用，超时即判为不解锁是正确的产品语义。
+	bahamutDefaultTimeout = 5 * time.Second
+	// bahamutRetryDeadline 控制整体上界：仅给 token.php CDN 偶发 5xx 留 1 次额外重试机会，
+	// 不再做长时间兜底。最多 2 次请求 × 5s 超时 = 10s 上界。
+	bahamutRetryDeadline = 10 * time.Second
+	bahamutMaxAttempts   = 2
 	// bahamutAdID 是巴哈姆特 token.php 接口固定的广告位参数
 	bahamutAdID = "89422"
 	// bahamutLenientSn 是入口探针动画 SN：港澳台 IP 均可获取 token，通过即表示在巴哈姆特服务区
@@ -174,10 +179,11 @@ func evaluateBahamutRegion(rawBody string) string {
 
 // bahamutClient 构造独立 client 用于 session 管理。
 // Transport 复用 runtime（必须走节点代理），cookie jar 独立（维持 deviceid→token session）。
+// Timeout 优先采纳 runtime.Timeout（已对齐全局解锁检测语义），仅在缺失时回退到默认值。
 func bahamutClient(runtime UnlockRuntime) *http.Client {
 	jar, _ := cookiejar.New(nil)
 	timeout := runtime.Timeout
-	if timeout <= 0 || timeout < bahamutDefaultTimeout {
+	if timeout <= 0 {
 		timeout = bahamutDefaultTimeout
 	}
 	return &http.Client{
@@ -189,7 +195,8 @@ func bahamutClient(runtime UnlockRuntime) *http.Client {
 }
 
 // bahamutFetchBody 执行 GET 请求并返回受限的 body。
-// 重试 3 次（参考项目语义），遇到 no such host / timeout 立即停止。
+// 最多重试 1 次（仅为容忍 token.php CDN 偶发 5xx），整体受 bahamutRetryDeadline 约束。
+// 遇到 DNS/超时/连接拒绝/TLS 握手等明确不可恢复错误立即停止重试。
 func bahamutFetchBody(client *http.Client, target string, headers map[string]string, bodyLimit int64) ([]byte, error) {
 	if bodyLimit <= 0 {
 		bodyLimit = bahamutProbeBodyLimit
@@ -201,7 +208,7 @@ func bahamutFetchBody(client *http.Client, target string, headers map[string]str
 
 	var lastErr error
 	deadline := time.Now().Add(bahamutRetryDeadline)
-	for i := 0; i < 3; i++ {
+	for i := 0; i < bahamutMaxAttempts; i++ {
 		if time.Now().After(deadline) {
 			break
 		}
@@ -238,12 +245,30 @@ func bahamutFetchBodyOnce(client *http.Client, target string, headers map[string
 	return io.ReadAll(io.LimitReader(resp.Body, bodyLimit))
 }
 
+// bahamutShouldStopRetry 判断错误是否属于"重试也不会更好"的不可恢复类。
+// 仅 token.php 的 CDN 5xx 这类瞬时错误才值得重试，其余一律短路返回。
 func bahamutShouldStopRetry(err error) bool {
 	if err == nil {
 		return false
 	}
 	errText := strings.ToLower(err.Error())
-	return strings.Contains(errText, "no such host") || strings.Contains(errText, "timeout")
+	stopKeywords := []string{
+		"no such host",
+		"timeout",
+		"deadline exceeded",
+		"connection refused",
+		"connection reset",
+		"tls",
+		"x509",
+		"certificate",
+		"proxy",
+	}
+	for _, kw := range stopKeywords {
+		if strings.Contains(errText, kw) {
+			return true
+		}
+	}
+	return false
 }
 
 func bahamutTokenURL(sn, deviceID string) string {


### PR DESCRIPTION
## 背景

巴哈姆特 checker 是 `services/unlock/` 下唯一与全局解锁检测语义不一致的离群点：

| 维度 | 全局默认（其他 checker） | 巴哈姆特（改前） |
|---|---|---|
| 单请求超时 | 5s（`runtime.go:34`） | 15s |
| 重试 | 无 | 3 次 |
| 整体上界 | 5s | 50s |

最差情况下，单个节点的巴哈姆特检测会拖到 **50s**，而其他 checker 全部在 5s 内返回。在批量节点扫描场景下，这个差距会显著放大用户感知的"卡顿"。

## 根因

原实现参考 `MediaUnlockTest/checks/BahamutAnime.go` 的兜底策略，但两者使用场景不同：

- **MediaUnlockTest**：独立 CLI 工具，对单出口跑一次，等 50s 无所谓
- **sublinkPro**：批量节点 × 多 provider 扫描，单 provider 拖 50s 直接破坏体验

而且解锁检测的产品语义与节点延迟测试不同 —— 慢节点即使解锁成功用户也不会选用，**超时即判为不解锁是正确的产品语义**，不需要为慢节点保留宽裕的兜底窗口。

## 改动

`services/unlock/checker_bahamut.go`：

1. **`bahamutDefaultTimeout`：15s → 5s**，与 `runtime.go` 全局默认对齐
2. **`bahamutRetryDeadline`：50s → 10s**，仅给 token.php CDN 偶发 5xx 留 1 次重试机会
3. **新增 `bahamutMaxAttempts = 2`**，替换硬编码的 `3`
4. **移除 `bahamutClient` 的 timeout floor**：原代码强制把 `runtime.Timeout` 拔到 15s，现在尊重外部传入
5. **扩展 `bahamutShouldStopRetry` 短路关键字**：新增 `deadline exceeded` / `connection refused` / `connection reset` / `tls` / `x509` / `certificate` / `proxy`，避免对明确不可恢复的错误浪费重试次数

## 耗时上界对比

| 节点状态 | 改前最差 | 改后最差 |
|---|---|---|
| token.php CDN 5xx 抖动 | 45s | **10s** |
| 节点慢但能通 | 15s | **5s** |
| TLS / 证书 / 连接拒绝 | 45s（仍走完 3 次重试） | **5s** |
| 完全不在服务区（多数节点） | ~3s（短路，不变） | ~3s（不变） |
| 港澳台正常解锁 | ~3s（不变） | ~3s（不变） |

## 风险评估

- **token.php 真实 5xx 抖动**：仍保留 1 次重试 + 10s 上界覆盖，对真实抖动场景影响极小
- **慢节点假失败**：本就是预期行为，与其他 checker 语义一致
- **判定逻辑（`evaluateBahamutUnlockProbe` 等纯函数）**：未改动，所有判定分支测试继续通过

## 验证

- [x] `gofmt -w services/unlock/checker_bahamut.go`
- [x] `go vet ./services/unlock/...`
- [x] `go build ./...`
- [x] `go test ./services/unlock/ -count=1` 全部通过

## 影响范围

- 后端：仅 `services/unlock/checker_bahamut.go`
- 前端：无
- 文档：无（`docs/features/unlock-check.zh-CN.md` 未涉及超时/重试细节）
- 配置：无
