### PR TITLE
fix(protocol): 保留 SSR 协议与混淆参数

### DIFF
--- a/node/protocol/clash.go
+++ b/node/protocol/clash.go
@@ -161,6 +161,8 @@ type Proxy struct {
 	Psk                   string         `yaml:"psk,omitempty"`                         // Snell 预共享密钥
 	Obfs_opts             map[string]any `yaml:"obfs-opts,omitempty"`                   // Snell 混淆选项 (mode/host)
 	Protocol              string         `yaml:"protocol,omitempty"`                    // SSR 协议
+	ProtocolParam         string         `yaml:"protocol-param,omitempty"`              // SSR 协议参数
+	ObfsParam             string         `yaml:"obfs-param,omitempty"`                  // SSR 混淆参数
 	Uuid                  string         `yaml:"uuid,omitempty"`                        // UUID (VMess/VLESS)
 	Peer                  string         `yaml:"peer,omitempty"`                        // Peer (Hysteria)
 	Congestion_controller string         `yaml:"congestion-controller,omitempty"`       // 拥塞控制 (Tuic)

--- a/node/protocol/ssr.go
+++ b/node/protocol/ssr.go
@@ -29,7 +29,7 @@ func init() {
 
 // ssr格式编码输出
 // EncodeSSRURL 将 SSR 结构编码为 ssr:// 链接。
-// 当前实现只输出仓库内已落地支持的查询字段，其余可选参数不会在这里补写。
+// 当前实现输出节点名称、协议参数与混淆参数，其余可选参数不会在这里补写。
 func EncodeSSRURL(s Ssr) string {
 	/*编码格式
 	ssr://base64(host:port:protocol:method:obfs:base64(password)/?obfsparam=base64(obfsparam)&protoparam=base64(protoparam)&remarks=base64(remarks)&group=base64(group))
@@ -49,6 +49,11 @@ func EncodeSSRURL(s Ssr) string {
 		queryParts = append(queryParts, "obfsparam="+utils.Base64Encode(s.Qurey.Obfsparam))
 	}
 
+	// protoparam 参与部分 SSR 协议的握手认证，非空时必须保留
+	if s.Qurey.Protoparam != "" {
+		queryParts = append(queryParts, "protoparam="+utils.Base64Encode(s.Qurey.Protoparam))
+	}
+
 	param := fmt.Sprintf("%s:%s:%s:%s:%s:%s/?%s",
 		s.Server,
 		utils.GetPortString(s.Port),
@@ -61,7 +66,7 @@ func EncodeSSRURL(s Ssr) string {
 	return "ssr://" + utils.Base64Encode(param)
 }
 
-// DecodeSSRURL 解析 SSR 链接，并按当前实现提取 remarks 与 obfsparam 等已支持字段。
+// DecodeSSRURL 解析 SSR 链接，并提取 remarks、obfsparam 与 protoparam。
 // 该解析流程依赖既有编码格式，对未覆盖的扩展参数会保持忽略。
 func DecodeSSRURL(s string) (Ssr, error) {
 	/*解析格式
@@ -74,7 +79,7 @@ func DecodeSSRURL(s string) (Ssr, error) {
 	}
 	s = parts[0] + utils.Base64Decode(parts[1])
 	// 检查是否包含"/?" 如果有就是有备注信息
-	var remarks, obfsparam string
+	var remarks, obfsparam, protoparam string
 	if strings.Contains(s, "/?") {
 		// 解析备注信息
 		query := strings.Split(s, "/?")[1]
@@ -96,10 +101,12 @@ func DecodeSSRURL(s string) (Ssr, error) {
 		}
 		remarks = utils.Base64Decode(paramMap["remarks"])
 		obfsparam = utils.Base64Decode(paramMap["obfsparam"])
+		protoparam = utils.Base64Decode(paramMap["protoparam"])
 		defer func() {
 			if utils.CheckEnvironment() {
 				fmt.Println("remarks", remarks)
 				fmt.Println("obfsparam", obfsparam)
+				fmt.Println("protoparam", protoparam)
 			}
 		}()
 	}
@@ -134,8 +141,9 @@ func DecodeSSRURL(s string) (Ssr, error) {
 		Obfs:     obfs,
 		Password: password,
 		Qurey: Ssrquery{
-			Obfsparam: obfsparam,
-			Remarks:   remarks,
+			Obfsparam:  obfsparam,
+			Protoparam: protoparam,
+			Remarks:    remarks,
 		},
 		Type: "ssr",
 	}, nil
@@ -152,8 +160,9 @@ type Ssr struct {
 	Type     string
 }
 type Ssrquery struct {
-	Obfsparam string
-	Remarks   string
+	Obfsparam  string
+	Protoparam string
+	Remarks    string
 }
 
 // ConvertProxyToSsr 将 Proxy 结构体转换为 Ssr 结构体
@@ -167,8 +176,9 @@ func ConvertProxyToSsr(proxy Proxy) Ssr {
 		Obfs:     proxy.Obfs,
 		Password: proxy.Password,
 		Qurey: Ssrquery{
-			Obfsparam: proxy.Obfs_password,
-			Remarks:   proxy.Name,
+			Obfsparam:  proxy.ObfsParam,
+			Protoparam: proxy.ProtocolParam,
+			Remarks:    proxy.Name,
 		},
 		Type: "ssr",
 	}
@@ -183,5 +193,5 @@ func buildSSRProxy(link Urls, config OutputConfig) (Proxy, error) {
 	if ssr.Qurey.Remarks == "" {
 		ssr.Qurey.Remarks = fmt.Sprintf("%s:%s", ssr.Server, utils.GetPortString(ssr.Port))
 	}
-	return Proxy{Name: ssr.Qurey.Remarks, Type: "ssr", Server: ssr.Server, Port: FlexPort(utils.GetPortInt(ssr.Port)), Cipher: ssr.Method, Password: ssr.Password, Obfs: ssr.Obfs, Obfs_password: ssr.Qurey.Obfsparam, Protocol: ssr.Protocol, Udp: config.Udp, Skip_cert_verify: config.Cert, Dialer_proxy: link.DialerProxyName}, nil
+	return Proxy{Name: ssr.Qurey.Remarks, Type: "ssr", Server: ssr.Server, Port: FlexPort(utils.GetPortInt(ssr.Port)), Cipher: ssr.Method, Password: ssr.Password, Obfs: ssr.Obfs, ObfsParam: ssr.Qurey.Obfsparam, Protocol: ssr.Protocol, ProtocolParam: ssr.Qurey.Protoparam, Udp: config.Udp, Skip_cert_verify: config.Cert, Dialer_proxy: link.DialerProxyName}, nil
 }

--- a/node/protocol/ssr_test.go
+++ b/node/protocol/ssr_test.go
@@ -1,0 +1,61 @@
+package protocol
+
+import (
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// TestSSRClashYAMLParametersRoundTrip 验证 SSR 专用参数在 Clash YAML 与 SSR 链接之间不会丢失。
+func TestSSRClashYAMLParametersRoundTrip(t *testing.T) {
+	var config struct {
+		Proxies []Proxy `yaml:"proxies"`
+	}
+	err := yaml.Unmarshal([]byte(`proxies:
+  - name: imported-ssr
+    type: ssr
+    server: ssr.example.com
+    port: 8388
+    cipher: aes-256-cfb
+    password: test-password
+    protocol: auth_aes128_md5
+    protocol-param: "30135:test-user-key"
+    obfs: http_simple
+    obfs-param: download.example.com
+`), &config)
+	if err != nil {
+		t.Fatalf("yaml unmarshal failed: %v", err)
+	}
+	if len(config.Proxies) != 1 {
+		t.Fatalf("proxy count = %d, want 1", len(config.Proxies))
+	}
+
+	link, err := EncodeProxyLink(config.Proxies[0])
+	if err != nil {
+		t.Fatalf("EncodeProxyLink failed: %v", err)
+	}
+	decoded, err := DecodeSSRURL(link)
+	if err != nil {
+		t.Fatalf("DecodeSSRURL failed: %v", err)
+	}
+	assertEqualString(t, "ProtocolParam", "30135:test-user-key", decoded.Qurey.Protoparam)
+	assertEqualString(t, "ObfsParam", "download.example.com", decoded.Qurey.Obfsparam)
+
+	rebuilt, err := buildSSRProxy(Urls{Url: link}, OutputConfig{})
+	if err != nil {
+		t.Fatalf("buildSSRProxy failed: %v", err)
+	}
+	data, err := yaml.Marshal(rebuilt)
+	if err != nil {
+		t.Fatalf("yaml marshal failed: %v", err)
+	}
+	for _, want := range []string{
+		"protocol-param: 30135:test-user-key",
+		"obfs-param: download.example.com",
+	} {
+		if !strings.Contains(string(data), want) {
+			t.Fatalf("Clash YAML output missing %q: %s", want, string(data))
+		}
+	}
+}


### PR DESCRIPTION
## 描述

修复 Clash YAML 导入 SSR 节点时，`protocol-param` 和 `obfs-param` 被静默丢弃的问题。

SublinkPro 原有 `Proxy` 数据模型未接收这两个 SSR 专用字段，导致机场订阅虽然能够正常导入，但生成的 SSR 链接缺少认证参数。对于 `auth_aes128_md5` 等依赖 `protocol-param` 的节点，会进一步造成 Mihomo 延迟测试和实际连接失败。

本次修改遵循最小化侵入原则，仅补齐 SSR 参数的数据模型、链接编解码和反向导出链路，不修改数据库结构、API、前端及其他协议实现。

## 关联 Issue

无关联 Issue。

## 更改类型

- [x] 🐛 修复 Bug (Bug)
- [ ] ✨ 新功能 (Feature)
- [ ] 📝 文档更新 (Docs)
- [ ] 🎨 样式或界面改进 (UI)
- [ ] ♻️ 代码重构 (Refactor)
- [ ] ⚡ 性能优化 (Perf)
- [ ] 🔧 配置更改 (Config)
- [x] 🧪 测试更新 (Test)

## 更改内容

- 为 Clash `Proxy` 数据模型补充 `protocol-param` 和 `obfs-param` 字段。
- 补齐 SSR 链接中 `protoparam`、`obfsparam` 的编码、解码和双向转换。
- 增加 Clash YAML → SSR 链接 → Clash YAML 往返回归测试，确保参数不会再次丢失。

## 截图
<img width="2705" height="1066" alt="PixPin_2026-07-22_02-15-22" src="https://github.com/user-attachments/assets/fa7169da-2146-4e7d-85c4-5453a3cf0377" />
本次修改仅涉及后端 SSR 协议转换逻辑，无 UI 变更。

## 检查清单

- [x] 我的代码遵循项目代码风格

- [x] 后端检查已通过

  ```text
  golangci-lint run
  go test ./...
  ```
- [ ] 前端改动已运行 `yarn run lint`

- [ ] UI 改动已检查 light/dark 和响应式状态

- [x] 已按需补充或更新后端测试、注释和文档

- [x] 行为或契约变化时，已检查跨层同步

- [x] 本次更改不会引入安全漏洞

已运行命令或检查：

```text
gofmt -l
golangci-lint run
go test ./...
```

验证结果：

```text
gofmt -l 无输出
golangci-lint run：0 issues
go test ./...：全部通过
真实 SSR 订阅重新导入后，54/54 个节点均保留 protocol-param
SublinkPro 调用 Mihomo 执行实际节点检测成功
```

## 其他说明

- 前端、UI、API 和数据库结构均未修改，因此前端 lint、主题及响应式检查不适用。
- `obfs-param` 在 `plain` 混淆模式下通常为空；本次仍补齐该字段，以支持使用其他 SSR 混淆模式的订阅。
- 修复不会自动恢复数据库中此前已经丢失的参数，现有机场需要重新拉取一次订阅。
```