### PR TITLE
fix(protocol): preserve VLESS HTTP upgrade URI options

### DIFF
--- a/node/protocol/vless.go
+++ b/node/protocol/vless.go
@@ -215,6 +215,13 @@ func EncodeVLESSURL(v VLESS) string {
 	if v.Query.EarlyDataHeader != "" {
 		q.Set("eh", v.Query.EarlyDataHeader)
 	}
+	// 保留 HTTP Upgrade 扩展，避免 Mihomo 配置经 VLESS URI 往返转换后退化为普通 WebSocket。
+	if v.Query.HttpUpgrade == 1 {
+		q.Set("httpUpgrade", "1")
+	}
+	if v.Query.HttpUpgradeFastOpen == 1 {
+		q.Set("httpUpgradeFastOpen", "1")
+	}
 
 	// http传输层参数
 	if v.Query.Method != "" {

--- a/node/protocol/vless_test.go
+++ b/node/protocol/vless_test.go
@@ -14,15 +14,17 @@ func TestVlessEncodeDecode(t *testing.T) {
 		Server: "example.com",
 		Port:   443,
 		Query: VLESSQuery{
-			Security:    "tls",
-			Encryption:  "none",
-			Type:        "ws",
-			Host:        "cdn.example.com",
-			Path:        "/vless",
-			Sni:         "sni.example.com",
-			Fp:          "chrome",
-			Fingerprint: "16dac3717024eb319093d1c95290c14adc850e2814b2208d11c7b7a436923859",
-			Alpn:        []string{"h2", "http/1.1"},
+			Security:            "tls",
+			Encryption:          "none",
+			Type:                "ws",
+			Host:                "cdn.example.com",
+			Path:                "/vless",
+			Sni:                 "sni.example.com",
+			Fp:                  "chrome",
+			Fingerprint:         "16dac3717024eb319093d1c95290c14adc850e2814b2208d11c7b7a436923859",
+			Alpn:                []string{"h2", "http/1.1"},
+			HttpUpgrade:         1,
+			HttpUpgradeFastOpen: 1,
 		},
 	}
 
@@ -47,6 +49,8 @@ func TestVlessEncodeDecode(t *testing.T) {
 	assertEqualString(t, "Query.Sni", original.Query.Sni, decoded.Query.Sni)
 	assertEqualString(t, "Query.Fingerprint", original.Query.Fingerprint, decoded.Query.Fingerprint)
 	assertEqualString(t, "Query.Path", original.Query.Path, decoded.Query.Path)
+	assertEqualInt(t, "Query.HttpUpgrade", original.Query.HttpUpgrade, decoded.Query.HttpUpgrade)
+	assertEqualInt(t, "Query.HttpUpgradeFastOpen", original.Query.HttpUpgradeFastOpen, decoded.Query.HttpUpgradeFastOpen)
 
 	t.Logf("✓ VLESS 编解码测试通过，名称: %s", decoded.Name)
 }


### PR DESCRIPTION
## 描述

修复 VLESS URI 编码未保留 HTTP Upgrade 扩展的问题，确保 Mihomo 节点经过“配置 → URI → 配置”往返转换后仍使用原有传输方式。

## 关联 Issue

Fixes #262

## 更改类型

- [x] 🐛 修复 Bug (Bug)
- [ ] ✨ 新功能 (Feature)
- [ ] 📝 文档更新 (Docs)
- [ ] 🎨 样式或界面改进 (UI)
- [ ] ♻️ 代码重构 (Refactor)
- [ ] ⚡ 性能优化 (Perf)
- [ ] 🔧 配置更改 (Config)
- [x] 🧪 测试更新 (Test)

## 更改内容

- 当 `HttpUpgrade` 启用时，在 VLESS URI 中写入 `httpUpgrade=1`
- 当 `HttpUpgradeFastOpen` 启用时，在 VLESS URI 中写入 `httpUpgradeFastOpen=1`
- 扩展现有 VLESS 编解码测试，验证两个字段均可无损往返

## 截图

不适用。

## 检查清单

- [x] 我的代码遵循项目代码风格

- [ ] 后端检查已通过

  ```text
  golangci-lint run
  go test ./...
  ```

- [ ] 前端改动已运行 `yarn run lint`

- [ ] UI 改动已检查 light/dark 和响应式状态

- [x] 已按需补充或更新后端测试、注释和文档

- [x] 行为或契约变化时，已检查跨层同步

- [x] 本次更改不会引入安全漏洞

已运行命令或检查：

```text
gofmt -l <all Go files>                                  # 通过，无输出
go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run  # 通过，0 issues
go test ./node/protocol -run TestVlessEncodeDecode -count=1                # 通过
go test <all packages except sublink/api>                                  # 通过
go test ./...                                                               # node/protocol 通过；Windows 下既有 api 测试失败
```

本地全量测试的 `api` 失败与本改动无关：部分测试将 Windows `t.TempDir()` 返回的反斜杠路径直接拼入 JSON，随后返回“配置读取错误”。PR 的 Linux GitHub Actions 将继续执行仓库规定的完整 `go test ./...`。

## 其他说明

这是编码器层面的最小修复。URI 解码、Mihomo 导入和 Mihomo 输出路径已经支持这两个字段，无需修改 API、前端、配置或文档。