### PR TITLE
feat(node): Surge 导出透传 hysteria2 端口跳跃(port-hopping)

### DIFF
--- a/node/protocol/hy2.go
+++ b/node/protocol/hy2.go
@@ -232,12 +232,98 @@ func buildHY2SurgeLine(link string, config OutputConfig) (string, string, error)
 	}
 	server := replaceSurgeHost(hy2.Host, config)
 	skipCert := config.Cert || hy2.Insecure == 1
-	line := fmt.Sprintf("%s = hysteria2, %s, %d, password=%s, udp-relay=%t, skip-cert-verify=%t", hy2.Name, server, utils.GetPortInt(hy2.Port), hy2.Password, true, skipCert)
+	port := utils.GetPortInt(hy2.Port)
+	// 端口跳跃：hy2:// 的 mport 透传为 Surge hysteria2 的 port-hopping。
+	// 先统一做白名单校验并规范化分隔符；非法或空串则本行不输出 port-hopping。
+	mphop := surgePortHopping(hy2.MPort)
+	// 主端口必须为 1-65535：显式 :0 或越界值会被 Surge 判为
+	// "The value of port is invalid"。此时若配置了合法端口跳跃则取 mport 首段作占位端口，
+	// 否则回退 443（与协议层 hysteria2 无端口时的默认端口一致）。
+	if port < 1 || port > 65535 {
+		if mphop != "" {
+			port = mportFirstPort(mphop)
+		}
+		if port < 1 || port > 65535 {
+			port = 443
+		}
+	}
+	line := fmt.Sprintf("%s = hysteria2, %s, %d, password=%s, udp-relay=%t, skip-cert-verify=%t", hy2.Name, server, port, hy2.Password, true, skipCert)
 	if hy2.Sni != "" {
 		line = fmt.Sprintf("%s, sni=%s", line, hy2.Sni)
 	}
 	if hy2.Fingerprint != "" {
 		line = fmt.Sprintf("%s, server-cert-fingerprint-sha256=%s", line, hy2.Fingerprint)
 	}
+	// 端口跳跃已在上方校验并规范化（mphop），非空才输出。
+	if mphop != "" {
+		line = fmt.Sprintf("%s, port-hopping=%s", line, mphop)
+	}
 	return line, hy2.Name, nil
+}
+
+// surgePortHopping 将 Hysteria2/mihomo 的 mport 端口跳跃串规范化为 Surge 语法。
+// mihomo 允许逗号或斜杠分隔多个端口段，并容忍端口段周围空白；这里先统一为
+// 规范端口/范围列表，再用 Surge 要求的分号连接。分号不是 mihomo 源语法，
+// 含分号或其他非法内容时整段丢弃，避免将未校验文本拼入 Surge profile。
+func surgePortHopping(mport string) string {
+	mport = strings.TrimSpace(mport)
+	if mport == "" || strings.Contains(mport, ";") {
+		return ""
+	}
+	mport = strings.ReplaceAll(mport, "/", ",")
+
+	// 语义校验：每段端口/端点须在 1-65535 且范围 start<=end。Surge 对降序范围、
+	// 端口 0 或超界会判 "The value of port-hopping is invalid"，导致整个 profile 无法加载；
+	// 任一非法则该 mport 整体视为无效，不输出 port-hopping。
+	segments := strings.Split(mport, ",")
+	normalized := make([]string, 0, len(segments))
+	for _, seg := range segments {
+		value, ok := normalizePortRange(seg)
+		if !ok {
+			return ""
+		}
+		normalized = append(normalized, value)
+	}
+	return strings.Join(normalized, ";")
+}
+
+// normalizePortRange 校验并规范化单段端口跳跃：`port` 或 `port-port`。
+// 端点须在 1-65535 且 start<=end；端点周围空白与前导零会被清理。
+func normalizePortRange(seg string) (string, bool) {
+	parts := strings.Split(strings.TrimSpace(seg), "-")
+	if len(parts) < 1 || len(parts) > 2 {
+		return "", false
+	}
+	lo, ok := portBound(strings.TrimSpace(parts[0]))
+	if !ok {
+		return "", false
+	}
+	if len(parts) == 1 {
+		return strconv.Itoa(lo), true
+	}
+	hi, ok := portBound(strings.TrimSpace(parts[1]))
+	if !ok || lo > hi {
+		return "", false
+	}
+	return fmt.Sprintf("%d-%d", lo, hi), true
+}
+
+// portBound 解析单个端口/端点并在 1-65535 范围内返回。
+func portBound(s string) (int, bool) {
+	n, err := strconv.Atoi(s)
+	if err != nil || n < 1 || n > 65535 {
+		return 0, false
+	}
+	return n, true
+}
+
+// mportFirstPort 从已规范化的 Surge port-hopping 中提取首段起始端口，
+// 供主端口无效时作占位主端口。解析失败返回 0，由调用方回退默认端口。
+func mportFirstPort(portHopping string) int {
+	firstSegment := strings.SplitN(portHopping, ";", 2)[0]
+	firstPort := strings.SplitN(firstSegment, "-", 2)[0]
+	if n, ok := portBound(firstPort); ok {
+		return n
+	}
+	return 0
 }

--- a/node/protocol/hy_test.go
+++ b/node/protocol/hy_test.go
@@ -173,3 +173,213 @@ func TestHY2IPv6RawUpdatePreservesBracketedAuthority(t *testing.T) {
 	}
 	assertEqualString(t, "Address", "[2001:db8::3]:22000", identity.Address)
 }
+
+func TestHY2SurgeLinePortHopping(t *testing.T) {
+	link := EncodeHY2URL(HY2{
+		Name:     "Surge-HY2-Hop",
+		Host:     "example.com",
+		Port:     443,
+		Password: "pw",
+		MPort:    "10000-20000",
+	})
+
+	line, name, err := buildHY2SurgeLine(link, OutputConfig{})
+	if err != nil {
+		t.Fatalf("buildHY2SurgeLine 失败: %v", err)
+	}
+	assertEqualString(t, "SurgeName", "Surge-HY2-Hop", name)
+	assertContains(t, "SurgeType", line, "Surge-HY2-Hop = hysteria2, example.com, 443")
+	assertContains(t, "PortHopping", line, "port-hopping=10000-20000")
+}
+
+func TestHY2SurgeLineNoPortHoppingWhenMPortEmpty(t *testing.T) {
+	link := EncodeHY2URL(HY2{
+		Name:     "Surge-HY2-Plain",
+		Host:     "example.com",
+		Port:     443,
+		Password: "pw",
+	})
+
+	line, _, err := buildHY2SurgeLine(link, OutputConfig{})
+	if err != nil {
+		t.Fatalf("buildHY2SurgeLine 失败: %v", err)
+	}
+	assertContains(t, "SurgeType", line, "Surge-HY2-Plain = hysteria2, example.com, 443")
+	if strings.Contains(line, "port-hopping") {
+		t.Errorf("无 mport 时不应输出 port-hopping, 实际: %s", line)
+	}
+}
+
+// TestHY2SurgeLinePortZeroUsesMportFirstPort 覆盖相邻 codex 审核指出的 P1：
+// 原始链接携带 :0（实际端口由 mport 提供）时，Surge 主端口必须取 mport 首段作占位，
+// 否则输出 "port = 0" 会被 Surge 判为 "The value of port is invalid"。
+func TestHY2SurgeLinePortZeroUsesMportFirstPort(t *testing.T) {
+	line, name, err := buildHY2SurgeLine("hy2://pw@example.com:0?mport=10000-20000,30000#Surge-Zero", OutputConfig{})
+	if err != nil {
+		t.Fatalf("buildHY2SurgeLine 失败: %v", err)
+	}
+	assertEqualString(t, "SurgeName", "Surge-Zero", name)
+	assertContains(t, "SurgeMainPort", line, " = hysteria2, example.com, 10000,")
+	assertContains(t, "PortHopping", line, "port-hopping=10000-20000;30000")
+}
+
+// TestHY2SurgeLineMportSeparatorToSemicolon 覆盖审核指出的 P1：
+// mport 多段以逗号分隔（10000-20000,30000），Surge 的 port-hopping 要求分号；
+// 直接透传逗号会让 Surge 将后续段解析成独立无效参数。
+func TestHY2SurgeLineMportSeparatorToSemicolon(t *testing.T) {
+	line, _, err := buildHY2SurgeLine("hy2://pw@example.com:443?mport=20000-30000,40000#Surge-Sep", OutputConfig{})
+	if err != nil {
+		t.Fatalf("buildHY2SurgeLine 失败: %v", err)
+	}
+	if strings.Contains(line, ",40000") {
+		t.Errorf("mport 多段逗号分隔应转换为分号, 实际: %s", line)
+	}
+	assertContains(t, "PortHopping", line, "port-hopping=20000-30000;40000")
+}
+
+func TestHY2SurgeLineMportNormalizesMihomoSyntax(t *testing.T) {
+	testCases := []struct {
+		name string
+		link string
+		want string
+	}{
+		{
+			name: "端口段空白",
+			link: "hy2://pw@example.com:443?mport=%2010000-20000%2C%2030000%20#Surge-Space",
+			want: "port-hopping=10000-20000;30000",
+		},
+		{
+			name: "斜杠分隔",
+			link: "hy2://pw@example.com:443?mport=10000-20000%2F30000#Surge-Slash",
+			want: "port-hopping=10000-20000;30000",
+		},
+		{
+			name: "范围端点空白",
+			link: "hy2://pw@example.com:443?mport=10000%20-%2020000%2F%2030000#Surge-Range-Space",
+			want: "port-hopping=10000-20000;30000",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			line, _, err := buildHY2SurgeLine(tc.link, OutputConfig{})
+			if err != nil {
+				t.Fatalf("buildHY2SurgeLine 失败: %v", err)
+			}
+			assertContains(t, "PortHopping", line, tc.want)
+		})
+	}
+}
+
+func TestHY2SurgeLineMportRejectsSemicolonInput(t *testing.T) {
+	line, _, err := buildHY2SurgeLine("hy2://pw@example.com:443?mport=10000-20000%3B30000#Surge-Semicolon", OutputConfig{})
+	if err != nil {
+		t.Fatalf("buildHY2SurgeLine 失败: %v", err)
+	}
+	if strings.Contains(line, "port-hopping") {
+		t.Errorf("mihomo mport 源输入不接受分号, 实际: %s", line)
+	}
+}
+
+// TestHY2SurgeLinePortZeroNoMportFallback443 覆盖主端口无效且无端口跳跃时回退默认端口 443。
+func TestHY2SurgeLinePortZeroNoMportFallback443(t *testing.T) {
+	line, _, err := buildHY2SurgeLine("hy2://pw@example.com:0#Surge-Fallback", OutputConfig{})
+	if err != nil {
+		t.Fatalf("buildHY2SurgeLine 失败: %v", err)
+	}
+	assertContains(t, "SurgeMainPort", line, " = hysteria2, example.com, 443,")
+	if strings.Contains(line, "port-hopping") {
+		t.Errorf("无 mport 时不应输出 port-hopping, 实际: %s", line)
+	}
+}
+
+// TestHY2SurgeLineMportRejectsInjection 覆盖相邻 codex 复核提出的 P2：
+// mport 白名单校验——URL 解码出的控制字符/换行等非法字符混入 mport 时丢弃整段，
+// 既不输出 port-hopping 也不把注入内容拼进生成的 Surge profile。
+func TestHY2SurgeLineMportRejectsInjection(t *testing.T) {
+	line, _, err := buildHY2SurgeLine("hy2://pw@example.com:443?mport=443%0A[Rule]%0AFINAL%2CDIRECT#Surge-Inject", OutputConfig{})
+	if err != nil {
+		t.Fatalf("buildHY2SurgeLine 失败: %v", err)
+	}
+	if strings.Contains(line, "port-hopping") {
+		t.Errorf("非法 mport 不应输出 port-hopping, 实际: %s", line)
+	}
+	if strings.Contains(line, "[Rule]") || strings.Contains(line, "\n") {
+		t.Errorf("非法 mport 不应注入 Surge 行, 实际: %s", line)
+	}
+}
+
+// TestHY2SurgeLineMportRangeOrderAndBound 覆盖 codex 三轮复核提出的 P2：
+// mport 语义校验——降序范围、端口 0、超 65535 等端口段 Surge 判 "port-hopping is invalid"，
+// 应整段丢弃不输出，避免生成无法加载的 profile。
+func TestHY2SurgeLineMportRangeOrderAndBound(t *testing.T) {
+	badMports := []string{"5000-4000", "0", "70000", "10000-20000,0", "10000-20000,300000"}
+	for _, mport := range badMports {
+		link := "hy2://pw@example.com:443?mport=" + mport + "#Surge-BadRange"
+		line, _, err := buildHY2SurgeLine(link, OutputConfig{})
+		if err != nil {
+			t.Fatalf("buildHY2SurgeLine 失败 (%s): %v", mport, err)
+		}
+		if strings.Contains(line, "port-hopping") {
+			t.Errorf("非法范围 mport=%q 不应输出 port-hopping, 实际: %s", mport, line)
+		}
+	}
+}
+
+func TestHY2SurgeLineInvalidMainPortFallback(t *testing.T) {
+	testCases := []struct {
+		name        string
+		link        string
+		wantPort    string
+		wantHopping string
+	}{
+		{
+			name:        "超界主端口取 mport 首段",
+			link:        "hy2://pw@example.com:70000?mport=10000-20000,30000#Surge-HighPort",
+			wantPort:    " = hysteria2, example.com, 10000,",
+			wantHopping: "port-hopping=10000-20000;30000",
+		},
+		{
+			name:     "超界主端口无 mport 回退 443",
+			link:     "hy2://pw@example.com:70000#Surge-HighPortFallback",
+			wantPort: " = hysteria2, example.com, 443,",
+		},
+		{
+			name:     "零端口加非法 mport 回退 443",
+			link:     "hy2://pw@example.com:0?mport=70000#Surge-InvalidMportFallback",
+			wantPort: " = hysteria2, example.com, 443,",
+		},
+		{
+			name:        "缺省主端口沿用协议默认 443",
+			link:        "hy2://pw@example.com?mport=10000-20000#Surge-MissingPort",
+			wantPort:    " = hysteria2, example.com, 443,",
+			wantHopping: "port-hopping=10000-20000",
+		},
+		{
+			name: "Encode 过滤零值 mport 后回退 443",
+			link: EncodeHY2URL(HY2{
+				Name:     "Surge-Encoded-Zero",
+				Host:     "example.com",
+				Port:     0,
+				Password: "pw",
+				MPort:    "0",
+			}),
+			wantPort: " = hysteria2, example.com, 443,",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			line, _, err := buildHY2SurgeLine(tc.link, OutputConfig{})
+			if err != nil {
+				t.Fatalf("buildHY2SurgeLine 失败: %v", err)
+			}
+			assertContains(t, "SurgeMainPort", line, tc.wantPort)
+			if tc.wantHopping != "" {
+				assertContains(t, "PortHopping", line, tc.wantHopping)
+			} else if strings.Contains(line, "port-hopping") {
+				t.Errorf("无合法 mport 时不应输出 port-hopping, 实际: %s", line)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**描述**

补上 Surge 导出的 hysteria2 端口跳跃（port-hopping）透传：`hy2://` 的 `mport` 参数此前仅 Clash/mihomo 侧（`buildHY2Proxy`）输出端口跳跃，Surge 侧（`buildHY2SurgeLine`）漏掉，导致带端口跳跃的 hysteria2 订阅导出 Surge 行时丢失该配置。

本次补上 `port-hopping` 输出，并处理以下兼容性和安全边界：

- **主端口占位与回退**：主端口为 `0`、缺失或超出 `1-65535` 时，优先取规范化后 `mport` 首段起始端口作为 Surge 占位主端口；没有合法 `mport` 时回退 `443`，避免输出 Surge 无法加载的端口。
- **mihomo 语法规范化**：兼容 `mport` 使用逗号或斜杠分隔，以及端口段、范围端点周围的空白；统一规范化为 Surge 要求的分号语法，例如 `10000 - 20000 / 30000` 输出为 `10000-20000;30000`。
- **分号源输入处理**：分号不是 mihomo `mport` 的源语法。源输入含分号时整段丢弃，而不是把它误当作已经规范化的 Surge 内容透传。
- **配置注入防护**：仅接受可规范化的数字端口或端口范围；含控制字符、换行或其他非法内容时整段丢弃，不向 Surge profile 拼接未经校验的文本。
- **端口范围语义校验**：每个端口必须在 `1-65535`，范围必须满足 `start<=end`；降序范围、端口 `0`、越界端口或任一非法分段均不输出 `port-hopping`。

`mport` 为空或非法时不输出 `port-hopping`，普通 hysteria2 节点保持原有导出行为。

**关联 Issue**

无关联上游 Issue（自行发现并修复）。这是 Surge 导出与 Clash/mihomo 端口跳跃能力的对称性补全，不涉及前端或 API 契约变更。

**更改类型**

- [x] 🐛 修复 Bug (Bug)
- [x] 🧪 测试更新 (Test)

**更改内容**

- `node/protocol/hy2.go`
  - `buildHY2SurgeLine` 输出 `port-hopping`
  - 主端口统一校验 `1-65535`，非法时取合法 `mport` 首段或回退 `443`
  - 兼容 mihomo 的逗号、斜杠和空白写法，并规范化为 Surge 分号语法
  - 拒绝源分号、配置注入内容及无效端口/范围
- `node/protocol/hy_test.go`
  - 新增 10 组 Surge 行回归测试，共覆盖 20 个场景
  - 覆盖普通输出、空 `mport`、`:0` 占位、逗号/斜杠转换、空白规范化、分号拒绝、注入拒绝、降序/零值/越界范围、超界或缺省主端口，以及 `EncodeHY2URL` 过滤零值 `mport` 后的回退路径

**截图**

N/A（无 UI 变更）

**检查清单**

- [x] 我的代码遵循项目代码风格
- [x] 后端检查已通过
- [x] 前端改动已运行 `yarn run lint`（N/A，无前端改动）
- [x] UI 改动已检查 light/dark 和响应式状态（N/A，无 UI 改动）
- [x] 已按需补充后端测试和注释
- [x] 已检查 `EncodeHY2URL` / `DecodeHY2URL` 的零值及缺省端口交互
- [x] `mport` 输出前完成规范化、范围校验与注入防护

已运行命令或检查：

```text
gofmt -l node/protocol/hy2.go node/protocol/hy_test.go
go vet ./node/protocol
go test -count=1 -run "TestHY2SurgeLine" ./node/protocol
go test -count=1 ./...
golangci-lint v2.12.2 run
git diff --check
```

验证结果：

- `gofmt` 无输出，格式正确
- `go vet ./node/protocol` 通过
- HY2 Surge 定向测试通过
- 全仓 Go 测试通过
- golangci-lint v2.12.2：`0 issues`
- 本机 Surge 6.9.0 `surge-cli --check` 对以下配置均返回 `OK`：
  - 空白/斜杠 `mport` 规范化
  - 超界主端口取合法 `mport` 首段
  - 源分号被拒绝后生成普通 hysteria2 节点

**其他说明**

- 本机 Surge 验证确认：`hy2://pw@example.com:0?mport=10000-20000,30000` 会输出合法主端口 `10000` 和 `port-hopping=10000-20000;30000`。
- 多轮复核提出的主端口 `0`、逗号分隔、配置注入、端口范围语义、空白/斜杠兼容和主端口超界问题均已覆盖。
- 范围限定在 Surge hysteria2 导出和对应测试，不改变 Clash/mihomo 输出、前端、API 或持久化契约。
- 本分支基准为 `upstream/dev`，PR base 请选 `dev`。
