### PR TITLE
fix(docs): 修复 README 中 Star 历史图表无法显示的问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ If your earlier instance used SQLite and you now want to migrate to MySQL or Pos
 
 [//]: # (  <img src="https://repobeez.abhijithganesh.com/api/insert/ZeroDeng01/sublinkPro" alt="Repobeez" height="0" width="0" style="display: none"/>)
   
-  ![Star History Chart](https://api.star-history.com/svg?repos=ZeroDeng01/sublinkPro&type=Date)
+  ![Star History Chart](https://star-history.dera.page/svg?repos=ZeroDeng01/sublinkPro&type=Date)
 </div>
 
 ---

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -218,7 +218,7 @@ docker-compose up -d
 
 [//]: # (  <img src="https://repobeez.abhijithganesh.com/api/insert/ZeroDeng01/sublinkPro" alt="Repobeez" height="0" width="0" style="display: none"/>)
   
-  ![Star History Chart](https://api.star-history.com/svg?repos=ZeroDeng01/sublinkPro&type=Date)
+  ![Star History Chart](https://star-history.dera.page/svg?repos=ZeroDeng01/sublinkPro&type=Date)
 </div>
 
 ---


### PR DESCRIPTION
## 背景

当前 README 中的 Star 历史图表无法正常显示，图表数据源受 GitHub stargazer API 限制影响已失效，图片一直加载失败。

## 改动

- 将 `README.md` 中的 Star 历史图表图片地址更新为可正常工作的新地址
- 同步更新 `README.zh-CN.md` 中对应的图表地址

## 验证

- 本地确认图表图片地址可正常访问
- 仅更新了图表地址，未影响 README 中其他内容